### PR TITLE
unit test support

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -131,7 +131,6 @@ func (f *Feature) RunUnitTests(_ *protoregistry.Types) error {
 		return err
 	}
 	for idx, test := range f.UnitTests {
-		fmt.Printf("Evaluating feature %v\n", test.Context)
 		a, err := eval.Evaluate(test.Context)
 		if err != nil {
 			return err

--- a/pkg/rules/v1beta2.go
+++ b/pkg/rules/v1beta2.go
@@ -15,8 +15,6 @@
 package rules
 
 import (
-	"fmt"
-
 	featurev1beta1 "github.com/lekkodev/cli/pkg/gen/proto/go/lekko/feature/v1beta1"
 
 	"github.com/lekkodev/rules/parser"
@@ -46,13 +44,11 @@ func traverseConstraint(constraint *featurev1beta1.Constraint, context map[strin
 	if err != nil {
 		return nil, errors.Wrap(err, "creating evaluator")
 	}
-	fmt.Printf("trying rule: %s and context: %+v %+v\n", constraint.Rule, context, evaluator)
 
 	passes, err := evaluator.Process(context)
 	if err != nil {
 		return nil, errors.Wrap(err, "processing")
 	}
-	fmt.Printf("result is: %t\n", passes)
 
 	if passes {
 		if constraint.Value != nil {

--- a/pkg/star/feature.go
+++ b/pkg/star/feature.go
@@ -135,7 +135,6 @@ func (fb *featureBuilder) validate(value starlark.Value) error {
 	if err != nil {
 		return errors.Wrap(err, "validator")
 	}
-	// log.Printf("validation result: %v, reporter: %v\n", result, vr)
 	return vr.toErr()
 }
 
@@ -317,7 +316,8 @@ func translateContext(dict *starlark.Dict) (map[string]interface{}, error) {
 		case starlark.Bool:
 			res = interface{}(v.Truth())
 		case starlark.String:
-			res = interface{}(v.GoString())
+			s := v.GoString()
+			res = interface{}(s)
 		case starlark.Int:
 			// Starlark uses math.Big under the hood, so technically
 			// we could get a very big number that doesn't fit in an i64.
@@ -338,8 +338,11 @@ func translateContext(dict *starlark.Dict) (map[string]interface{}, error) {
 		default:
 			return nil, fmt.Errorf("unsupported context value %T for context key %s", v, k)
 		}
-		// TODO: we may have to typecheck the key values. String repr for now should work fine.
-		m[k.String()] = res
+		str, ok := k.(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("invalid context key type %T for context key %v", k, k)
+		}
+		m[str.GoString()] = res
 	}
 	return m, nil
 }

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -66,7 +66,7 @@ func Verify(rootPath string) error {
 					if err := f.RunUnitTests(registry); err != nil {
 						fmt.Printf("FAIL: %v\n", err)
 					} else {
-						fmt.Printf("PASS: %v\n", err)
+						fmt.Println("PASS")
 					}
 				}
 			}


### PR DESCRIPTION
includes the `tests` attribute on features

Right now only runs on verify, but compile runs verify, so we should work out their relationship. This is fine for now.