### PR TITLE
Rules evaluation spec & tests

### DIFF
--- a/pkg/feature/README.md
+++ b/pkg/feature/README.md
@@ -1,0 +1,56 @@
+# Feature Tree
+
+Feature flags are stored as n-ary trees, with each non-root node having a rule and an optional default value.
+The root node has no rule, and has a non-optional default value.
+
+Feature evaluation traverses the n-ary in depth-first search fashion, starting at the root, and ending as soon as a leaf node evaluates to true or there are no further paths to traverse. 
+The algorithm returns the last non-null value it visited.
+
+```
+Feature Name: illustration
+Description: Complex feature tree to illustrate node paths
+
+
+                                            *Root*
+                                            Path: []
+                                            Value: 12
+                                            /   |   \
+                           -----------------    |    -------------------
+                          /                     |                        \
+                    Rule: a == 1            Rule: a > 10             Rule: a > 5
+                    Path: [0]               Path: [1]                Path: [2]
+                    Value: 38               Value: NULL              Value: 23
+                        /                       |
+             -----------                        |
+            /                                   |
+    Rule: x IN ["a", "b"]                   Rule: x == "c"
+    Path: [0,0]                             Path: [1,0]
+    Value: 108                              Value: 21
+   
+
+*** Tests ***
+
+Context: {}
+Value: 12
+Path: []
+
+Context: {"a": 1}
+Value: 38
+Path: [0]
+
+Context: {"a": 11}
+Value: 12
+Path: []
+
+Context: {"a": 11, "x": "c"}
+Value: 21
+Path: [1,0]
+
+Context: {"a": 8}
+Value: 23
+Path: [2]
+
+Context: {"a": 8}
+Value: 108
+Path: [0,0]
+```

--- a/pkg/feature/evaluate.go
+++ b/pkg/feature/evaluate.go
@@ -36,8 +36,12 @@ type EvaluableFeature interface {
 	// For user defined protos, we shouldn't attempt to Unmarshal
 	// this unless we know the type. For primitive types, we can
 	// safely unmarshal into BoolValue, StringValue, etc.
-	Evaluate(evalContext map[string]interface{}) (*anypb.Any, error)
+	Evaluate(evalContext map[string]interface{}) (*anypb.Any, ResultPath, error)
 }
+
+// Stores the path of the tree node that returned the final value
+// after successful evaluation. See the readme for an illustration.
+type ResultPath []int
 
 type v1beta3 struct {
 	*featurev1beta1.Feature
@@ -50,7 +54,7 @@ func NewV1Beta3(f *featurev1beta1.Feature) EvaluableFeature {
 // TODO: pre-compute the ruleslang tree so that we:
 // 1) error on verify time if things aren't valid.
 // 2) pre-compute antlr trees.
-func (v1b3 *v1beta3) Evaluate(evalContext map[string]interface{}) (*anypb.Any, error) {
+func (v1b3 *v1beta3) Evaluate(evalContext map[string]interface{}) (*anypb.Any, ResultPath, error) {
 	return rules.EvaluateFeatureV1Beta3(v1b3.Tree, evalContext)
 }
 

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -342,7 +342,7 @@ func (f *Feature) RunUnitTests(_ *protoregistry.Types) error {
 		return err
 	}
 	for idx, test := range f.UnitTests {
-		a, err := eval.Evaluate(test.Context)
+		a, _, err := eval.Evaluate(test.Context)
 		if err != nil {
 			return err
 		}

--- a/pkg/fixtures/fixtures.go
+++ b/pkg/fixtures/fixtures.go
@@ -180,6 +180,14 @@ func NewAnyTrue() *anypb.Any {
 	return a
 }
 
+func NewAnyInt(i int64) *anypb.Any {
+	a, err := anypb.New(&wrapperspb.Int64Value{Value: i})
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
 func NewRuleLangEqualUserID() string {
 	return "user_id == 1"
 }
@@ -190,4 +198,22 @@ func NewRuleLangContainsUserID() string {
 
 func NewRuleLangInvalid() string {
 	return "user_id IN (1, 2)"
+}
+
+func NewComplexTreeFeature() *featurev1beta1.Feature {
+	return &featurev1beta1.Feature{
+		Key: "complex-tree",
+		Tree: &featurev1beta1.Tree{
+			Default: NewAnyInt(12),
+			Constraints: []*featurev1beta1.Constraint{
+				{Rule: "a == 1", Value: NewAnyInt(38), Constraints: []*featurev1beta1.Constraint{
+					{Rule: "x IN [\"a\", \"b\"]", Value: NewAnyInt(108)},
+				}},
+				{Rule: "a > 10", Value: nil, Constraints: []*featurev1beta1.Constraint{
+					{Rule: "x == \"c\"", Value: NewAnyInt(21)},
+				}},
+				{Rule: "a > 5", Value: NewAnyInt(23)},
+			},
+		},
+	}
 }

--- a/pkg/repo/feature.go
+++ b/pkg/repo/feature.go
@@ -336,7 +336,8 @@ func (r *Repo) Eval(ctx context.Context, ns, featureName string, iCtx map[string
 		return nil, err
 	}
 
-	return evalF.Evaluate(iCtx)
+	ret, _, err := evalF.Evaluate(iCtx)
+	return ret, err
 }
 
 func (r *Repo) Parse(ctx context.Context, ns, featureName string) error {


### PR DESCRIPTION
Codify the spec for rules evaluation, and add more complicated tests of a multi-level tree.

Evaluation now returns the actual tree node that evaluated to true, useful for metrics.