### PR TITLE
Optional verify on compile

### DIFF
--- a/cmd/lekko/main.go
+++ b/cmd/lekko/main.go
@@ -192,6 +192,9 @@ func compileCmd() *cobra.Command {
 				FeatureFilter:                f,
 				Persist:                      !dryRun,
 				IgnoreBackwardsCompatibility: force,
+				// don't verify file structure, since we may have not yet generated
+				// the DSLs for newly added features.
+				Verify: false,
 			}); err != nil {
 				return errors.Wrap(err, "compile")
 			}
@@ -241,7 +244,9 @@ func reviewCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "new repo")
 			}
-			if _, err := r.Compile(ctx, &repo.CompileRequest{}); err != nil {
+			if _, err := r.Compile(ctx, &repo.CompileRequest{
+				Verify: true,
+			}); err != nil {
 				return errors.Wrap(err, "compile")
 			}
 
@@ -282,7 +287,9 @@ var mergeCmd = &cobra.Command{
 			return errors.Wrap(err, "new repo")
 		}
 		ctx := cmd.Context()
-		if _, err := r.Compile(ctx, &repo.CompileRequest{}); err != nil {
+		if _, err := r.Compile(ctx, &repo.CompileRequest{
+			Verify: true,
+		}); err != nil {
 			return errors.Wrap(err, "compile")
 		}
 		var prNum *int
@@ -523,7 +530,9 @@ func applyCmd() *cobra.Command {
 				return errors.Wrap(err, "new repo")
 			}
 			ctx := cmd.Context()
-			if _, err := r.Compile(ctx, &repo.CompileRequest{}); err != nil {
+			if _, err := r.Compile(ctx, &repo.CompileRequest{
+				Verify: true,
+			}); err != nil {
 				return errors.Wrap(err, "compile")
 			}
 			kube, err := k8s.NewKubernetes(kubeConfig, r)
@@ -614,7 +623,9 @@ func commitCmd() *cobra.Command {
 				return errors.Wrap(err, "new repo")
 			}
 			ctx := cmd.Context()
-			if _, err := r.Compile(ctx, &repo.CompileRequest{}); err != nil {
+			if _, err := r.Compile(ctx, &repo.CompileRequest{
+				Verify: true,
+			}); err != nil {
 				return errors.Wrap(err, "compile")
 			}
 			if _, err = r.Commit(ctx, message); err != nil {

--- a/pkg/repo/feature.go
+++ b/pkg/repo/feature.go
@@ -128,6 +128,11 @@ type CompileRequest struct {
 	// If true, any generated compilation changes will overwrite previous features
 	// even if there are type mismatches
 	IgnoreBackwardsCompatibility bool
+	// If true, we will verify the structure of all feature files, ensuring that each
+	// .star file has the relevant generated json and proto files, and all relevant compliance
+	// checks are run. This should be false if we've just added a new .star file and are
+	// compiling it for the first time.
+	Verify bool
 }
 
 type FeatureCompilationResult struct {
@@ -201,7 +206,7 @@ func (fcrs FeatureCompilationResults) Err() error {
 
 func (r *Repo) Compile(ctx context.Context, req *CompileRequest) ([]*FeatureCompilationResult, error) {
 	// Step 1: collect. Find all features
-	ffs, numNamespaces, err := r.FindFeatureFiles(ctx, req.NamespaceFilter, req.FeatureFilter, true)
+	ffs, numNamespaces, err := r.FindFeatureFiles(ctx, req.NamespaceFilter, req.FeatureFilter, req.Verify)
 	if err != nil {
 		return nil, errors.Wrap(err, "find features")
 	}


### PR DESCRIPTION
this PR fixes the following error:
```
➜  lekko add kudos/test
Your new feature has been written to kudos/test.star
Make your changes, and run 'lekko compile'.
➜  lekko compile
compile: find features: feature kudos/test verify: feature file test has no .json file
```