### PR TITLE
Add ConfirmUser to Auth Service

### DIFF
--- a/pkg/gen/proto/go/lekko/backend/v1beta1/configuration_service.pb.go
+++ b/pkg/gen/proto/go/lekko/backend/v1beta1/configuration_service.pb.go
@@ -804,7 +804,6 @@ type Value struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Kind:
-	//
 	//	*Value_BoolValue
 	//	*Value_IntValue
 	//	*Value_DoubleValue

--- a/pkg/gen/proto/go/lekko/rules/v1beta2/rules.pb.go
+++ b/pkg/gen/proto/go/lekko/rules/v1beta2/rules.pb.go
@@ -182,7 +182,6 @@ type Rule struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Rule:
-	//
 	//	*Rule_Atom
 	//	*Rule_Not
 	//	*Rule_LogicalExpression

--- a/pkg/gen/proto/go/lekko/rules/v1beta3/rules.pb.go
+++ b/pkg/gen/proto/go/lekko/rules/v1beta3/rules.pb.go
@@ -186,7 +186,6 @@ type Rule struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Rule:
-	//
 	//	*Rule_Atom
 	//	*Rule_Not
 	//	*Rule_LogicalExpression


### PR DESCRIPTION
Add `ConfirmUser` method to the Auth Service. This will enable users to confirm their accounts. While we're here, also add a `confirm_password` field to the `RegisterUser` method to verify that the input password matches on server-side.