### PR TITLE
Make Cli aware of its own version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
       - linux
       # - windows
       - darwin
+    ldflags:
+      - -X "main.version={{.Env.CLI_TAG}}"
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ DOCKER_PROJECT := cli
 FILE_IGNORES := .vscode/
 
 include make/cli/all.mk
+
+release:
+	./release.sh

--- a/README.md
+++ b/README.md
@@ -26,14 +26,7 @@ To install:
 brew install goreleaser
 ```
 
-In order to release a new version of `lekko`, first create a new tag.
-
-```bash
-git tag -a v0.1.0 -m "First release"
-git push origin v0.1.0
-```
-
-Then, export your Github access token to an environment variable. You can create a new GitHub token (here)[https://github.com/settings/tokens/new].
+To release, first export your Github access token to an environment variable. You can create a new GitHub token [here](https://github.com/settings/tokens/new).
 
 ```bash
 export GITHUB_TOKEN="YOUR_GH_TOKEN"
@@ -42,10 +35,10 @@ export GITHUB_TOKEN="YOUR_GH_TOKEN"
 Finally, create the release.
 
 ```bash
-goreleaser release
+make release
 ```
 
-That will cross-compile the binary for multiple platforms and architectures, using the latest tag found on github.
+This command will first prompt you for a new tag that it will push to GitHub. Then, it will cross-compile the binary for multiple platforms and architectures, using the latest tag on GitHub.
 
 After completion, navigate to https://github.com/lekkodev/cli/releases/ to see the latest releases under the tag you just created.
 

--- a/cmd/lekko/main.go
+++ b/cmd/lekko/main.go
@@ -39,6 +39,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Updated at build time using ldflags
+var version = "development"
+
 func main() {
 	rootCmd := rootCmd()
 	rootCmd.AddCommand(compileCmd())
@@ -80,7 +83,7 @@ func rootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "lekko",
 		Short:         "lekko - dynamic configuration helper",
-		Version:       "v0.2.4", // TODO: autoupdate this when releasing a new tag
+		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# First, ensure that the github token is set
+if [[ -z $GITHUB_TOKEN ]]; then
+  echo Github token not found. 
+  echo "Please set your github token via \"export GITHUB_TOKEN=<your-gh-token>\" and try again."
+  exit 1
+fi
+
+current_tag=`git describe --tags --abbrev=0`
+echo The current tag is $current_tag.
+echo What would you like the new tag to be?
+read new_tag
+tag_message=`git --no-pager log -1 --pretty=%s`
+
+echo Pushing $new_tag: $tag_message. 
+read -p "Continue? [y/N] " yn
+case $yn in
+    [Yy]* ) echo Pushing to remote...;;
+    * ) echo Exiting...; exit;;
+esac
+
+# Push tag
+git tag -a $new_tag -m $tag_message
+git push origin $new_tag
+
+read -p "Build and release cli binaries? [y/N] " yn
+case $yn in
+    [Yy]* ) echo Releasing...;;
+    * ) echo Exiting...; exit;;
+esac
+
+# Build & release, setting the tag as the lekko cli version via ldflags.
+export CLI_TAG=$new_tag
+goreleaser release --rm-dist


### PR DESCRIPTION
after this, the result of `lekko --version` will be correct and will match `brew info lekko`.

This doesn't automate the tagging and releasing process yet.