### PR TITLE
Upgrade to setup-go-v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,9 @@ jobs:
       - uses: bufbuild/buf-lint-action@v1
       - name: setup-go
         if: success()
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19.7
+          go-version-file: go.mod
       - name: ci
         env:
           GITHUB_TOKEN: ${{ secrets.CI_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Upgrade to [setup-go@v4](https://github.com/actions/setup-go#v4) which has [GitHub Action caching](https://github.com/actions/cache) enabled by default, this means dependencies need to be downloaded only if  `go.mod` changes. Also, use the go version specified in `go.mod`