### PR TITLE
Add challenge support to auth endpoints

### DIFF
--- a/proto/lekko/bff/v1beta1/auth_service.proto
+++ b/proto/lekko/bff/v1beta1/auth_service.proto
@@ -70,9 +70,14 @@ message LogoutRequest {}
 message LogoutResponse {}
 
 message RespondToChallengeRequest {
-  ChallengeName name = 1;
-  map<string, string> challenge_responses = 2;
-  string session_id = 3;
+  message NewPasswordRequired {
+    string new_password = 1;
+  }
+  string username = 1;
+  string session_id = 2;
+  oneof challenge_response {
+    NewPasswordRequired new_password_required = 3;
+  }
 }
 
 message RespondToChallengeResponse {}


### PR DESCRIPTION
Update `Login` to return back challenge name and a session ID. If the response is null then the client is authenticated otherwise they will require an additional challenge such as MFA or password change to authenticate. Additionally, add `RespondToChallenge` which is used to respond to challenges. User flow: https://excalidraw.com/#json=lOT_WWkRX9pCfegZaHabS,D5X-prkdZdIS2IIyL3w0tw