### PR TITLE
Show user status in list-members

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/lekkodev/cli
 go 1.19
 
 require (
-	buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.6.0-20230404170739-04ec1002972a.1
-	buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.30.0-20230404170739-04ec1002972a.1
+	buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.6.0-20230413010910-532fd8184ad4.1
+	buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.30.0-20230413010910-532fd8184ad4.1
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/bazelbuild/buildtools v0.0.0-20220907133145-b9bfff5d7f91
 	github.com/bufbuild/connect-go v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.6.0-20230404170739-04ec1002972a.1 h1:RY7Yym+GHzB3yn6YyGv58QMoP/yzQbQ2phGYFR8yrEM=
-buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.6.0-20230404170739-04ec1002972a.1/go.mod h1:y4D6oNuCOfwxq5pED+uWA3gJYi4t8/3w5IfnLHoARc8=
-buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.30.0-20230404170739-04ec1002972a.1 h1:NRg4yVzTnlK7P6EGNqW41Xc843V9+FA0WxN3Ik75C8w=
-buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.30.0-20230404170739-04ec1002972a.1/go.mod h1:k8LDgZDmmXoT8LRJBCFFt5AAu98aZh9IYZgtFPTNsAI=
+buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.6.0-20230413010910-532fd8184ad4.1 h1:dLR2hlAAB55sgJ/wu4y1V6wfQAuzZ3Ct8CpYIUMDvlk=
+buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.6.0-20230413010910-532fd8184ad4.1/go.mod h1:PhFH7Y2SqmNFM1s6Aj3F6vgxCcf/HvRuAyBtmTMOdPo=
+buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.30.0-20230413010910-532fd8184ad4.1 h1:5lr4nJRFm32bwLGJLCZhiZUhK1IlBKcFy5IrI5nASxs=
+buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.30.0-20230413010910-532fd8184ad4.1/go.mod h1:k8LDgZDmmXoT8LRJBCFFt5AAu98aZh9IYZgtFPTNsAI=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -84,9 +84,10 @@ func (m *MemberRole) Type() string {
 }
 
 type TeamMembership struct {
-	TeamName string
-	User     string
-	Role     string
+	TeamName   string
+	User       string
+	Role       string
+	UserStatus string
 }
 
 func (t *Team) List(ctx context.Context) ([]*TeamMembership, error) {
@@ -106,9 +107,10 @@ func teamMembershipFromProto(m *bffv1beta1.Membership) *TeamMembership {
 		return nil
 	}
 	return &TeamMembership{
-		TeamName: m.GetTeamName(),
-		User:     m.GetUsername(),
-		Role:     roleFromProto(m.GetRole()),
+		TeamName:   m.GetTeamName(),
+		User:       m.GetUsername(),
+		Role:       roleFromProto(m.GetRole()),
+		UserStatus: strings.ToLower(strings.TrimPrefix(m.GetUserStatus().String(), "USER_STATUS_")),
 	}
 }
 


### PR DESCRIPTION
Show `User Status` in the `list-members` command. Also add an `output` flag to switch output format because `table` format is not easily parsable for programmatic use cases.

```
lekko --backend-url http://127.0.0.1:8080 team list-members
Team Name      Email                Role    Status
lekko-staging  dan@lekko.com        owner   confirmed
lekko-staging  shubhitms@gmail.com  owner   confirmed
lekko-staging  konrad@lekko.com     owner   confirmed
lekko-staging  dan+222@lekko.com    member  confirmed
lekko-staging  dan+test1@lekko.com  member  confirmed
lekko-staging  dan11111@lekko.com   member  unconfirmed
lekko-staging  dan+new@lekko.com    member  unconfirmed
```

JSON output
```
lekko --backend-url http://127.0.0.1:8080 team list-members -o json
[
    {
        "TeamName": "lekko-staging",
        "User": "dan@lekko.com",
        "Role": "owner",
        "UserStatus": "confirmed"
    },
    ...
]
```