### PR TITLE
Handle repeated message types

### DIFF
--- a/pkg/repo/feature.go
+++ b/pkg/repo/feature.go
@@ -537,7 +537,11 @@ func addFeatureFromProto(r ConfigurationRepository, ctx context.Context, message
 			} else {
 				pkgName := string(field.Message().ParentFile().Package())
 				packageMap[pkgName] = packageAlias(pkgName)
-				fieldDefault += string(field.Message().FullName()) + "()"
+				instance := string(field.Message().FullName()) + "()"
+				if field.IsList() {
+					instance = fmt.Sprintf("[%s]", instance)
+				}
+				fieldDefault += instance
 			}
 		case protoreflect.EnumKind:
 			pkgName := string(field.Enum().ParentFile().Package())


### PR DESCRIPTION
For fields like: https://github.com/lekkodev/internal/blob/main/proto/default/config/v1beta1/default.proto#L40, the proto starlark generator was not checking if it's a list. We now instantiate the Starlark with an array with 1 of the message type in it. We could do something similar for primitives as it's only generating an empty list. eg: `[] vs. [""]` for repeated string.

.star file
```
default_config_v1beta1 = proto.package("default.config.v1beta1")
lekko_bff_v1beta1 = proto.package("lekko.bff.v1beta1")

result = feature(
    description = "my feature description",
    default = default_config_v1beta1.RepositoryConfig(
        critical_repositories = [lekko_bff_v1beta1.RepositoryKey()],
    ),
)
```

cli command:
```
? Namespace: default
? Feature Name: repo_config
? Feature Type: proto
? Messages: default.config.v1beta1.RepositoryConfig
Successfully added feature default/repo_config at path default/repo_config.star
Make any changes you wish, and then run `lekko compile`.Found 10 features across 1 namespaces
Compiling...
[default/alal] Compile (proto) ✔
[default/cookie-expiration-duration] Compile (proto) ✔ | Validate 1/1 ✔
[default/device-oauth] Compile (proto) ✔ | Validate 2/2 ✔
[default/error_filter] Compile (proto) ✔
[default/example] Compile (bool) ✔
[default/lalalal] Compile (proto) ✔
[default/middleware] Compile (proto) ✔ | Validate 1/1 ✔
[default/repo_config] Compile (proto) ✔
[default/repository] Compile (proto) ✔
[default/rollout] Compile (proto) ✔ | Validate 1/1 ✔
-------------------
Generated diff for default/repo_config
```