### PR TITLE
Indicate successful save starlark response

### DIFF
--- a/proto/lekko/bff/v1beta1/bff.proto
+++ b/proto/lekko/bff/v1beta1/bff.proto
@@ -671,6 +671,9 @@ message SaveStarlarkResponse {
   NamespaceContents namespace_contents = 2;
   Feature feature = 3;
   bytes output = 4;
+  // This rpc will return output bytes even if compilation
+  // failed. In that case, success will be false.
+  bool success = 5;
 }
 
 message ConvertRuleToStringRequest {


### PR DESCRIPTION
Right now, there's no way to indicate that compilation failed without throwing a 500. This pr adds a `success` field to the response so that we can return a payload in the event of a compilation failure, 
but set `success=false`. The FE will need to check this field and act accordingly
