### PR TITLE
Add struct module

### DIFF
--- a/pkg/star/compile.go
+++ b/pkg/star/compile.go
@@ -71,9 +71,9 @@ func (c *compiler) Compile(ctx context.Context, nv feature.NamespaceVersion) (*f
 	}
 	globals, err := starlark.ExecFile(thread, c.ff.RootPath(c.ff.StarlarkFileName), moduleSource, starlark.StringDict{
 		"assert":  assertModule,
+		"feature": starlark.NewBuiltin("feature", makeFeature),
 		"proto":   protoModule,
 		"struct":  starlark.NewBuiltin("struct", starlarkstruct.Make),
-		"feature": starlark.NewBuiltin("feature", makeFeature),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "starlark execfile")


### PR DESCRIPTION
Allow CLI to compile features with [struct](https://bazel.build/rules/lib/builtins/struct) usage

Current behavior:
```
compile: starlark execfile: customer/pricing-tiers.star:3:7: undefined: struct
```
