### PR TITLE
Fix silent error for invalid test

### DIFF
--- a/pkg/star/feature.go
+++ b/pkg/star/feature.go
@@ -401,7 +401,7 @@ func (fb *featureBuilder) addUnitTests(f *feature.Feature, featureVal *starlarks
 
 		expectedVal := tuple.Index(1)
 		if vr := fb.validate(feature.ValidatorResultTypeTest, i, expectedVal); vr != nil && vr.Error != nil {
-			return errors.Wrap(err, "test value validate")
+			return errors.Wrap(vr.Error, "test value validate")
 		}
 		switch f.FeatureType {
 		case feature.FeatureTypeProto:


### PR DESCRIPTION
A test with the incorrect type was silently being ignored. This change makes it so it raises the error.
`compile: build: add unit tests: test value validate: unknown binary op: string in int`