### PR TITLE
Create new repo via mirror

### DIFF
--- a/pkg/repo/repo_integration_test.go
+++ b/pkg/repo/repo_integration_test.go
@@ -141,7 +141,7 @@ func testReview(ctx context.Context, t *testing.T, r *repository, ghCli *gh.Gith
 }
 
 func testEphemeral(ctx context.Context, t *testing.T, ap AuthProvider, branchName string) {
-	cr, err := NewEphemeral(integrationTestURL, ap, branchName)
+	cr, err := NewEphemeral(integrationTestURL, ap, &branchName)
 	require.NoError(t, err)
 	r, ok := cr.(*repository)
 	require.True(t, ok)


### PR DESCRIPTION
Due to https://stackoverflow.com/a/59744483, the current method we use for creating new config 
repos doesn't work to create repos outside `lekkodev` or our own personal accounts. 

This PR introduces a new way to create a config repo. By first creating an empty repo using the 
github api, then cloning an ephemeral template repo, adding a new remote, and pushing `main` to 
that new remote.

One downside is that the commit history of `lekkodev/template` gets copied over to the newly 
created repo. In the future we can squash those commits before we push. However, as of now, 
go-git [doesn't support rebasing/squashing](https://github.com/go-git/go-git/blob/master/COMPATIBILITY.md).
