### PR TITLE
Store default branch symbolic ref

### DIFF
--- a/cmd/lekko/repo.go
+++ b/cmd/lekko/repo.go
@@ -47,7 +47,6 @@ func repoCmd() *cobra.Command {
 		repoCloneCmd(),
 		repoDeleteCmd(),
 		repoInitCmd(),
-		repoTestCmd(),
 	)
 	return cmd
 }
@@ -251,28 +250,5 @@ func repoInitCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&owner, "owner", "o", "", "github owner to house repository in")
 	cmd.Flags().StringVarP(&repoName, "repo", "r", "", "github repository name")
-	return cmd
-}
-
-func repoTestCmd() *cobra.Command {
-	var url string
-	cmd := &cobra.Command{
-		Use:   "test",
-		Short: "test",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			wd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			rs := secrets.NewSecretsOrFail(secrets.RequireLekko())
-			r, err := repo.NewLocal(wd, rs)
-			if err != nil {
-				return errors.Wrap(err, "new local")
-			}
-			fmt.Println(r.DefaultBranchName())
-			return nil
-		},
-	}
-	cmd.Flags().StringVarP(&url, "url", "u", "", "url of GitHub-hosted configuration repository to clone")
 	return cmd
 }


### PR DESCRIPTION
By default, `go-git` does not fetch the symbolic ref that allows us to determine what the 
default branch is locally. To get around this, we will now query the remote to determine the 
default branch at repo clone time, and store the symbolic reference locally if it is missing.

This allows any subsequent run of the cli to have the default branch available by reading from the filesystem similar to 

```
$ git symbolic-ref refs/remotes/origin/HEAD
---
refs/remotes/origin/main
```
