### PR TITLE
Add math starlark module

### DIFF
--- a/pkg/star/compile.go
+++ b/pkg/star/compile.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lekkodev/cli/pkg/metadata"
 	"github.com/pkg/errors"
 	"github.com/stripe/skycfg/go/protomodule"
+	"go.starlark.net/lib/math"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"go.starlark.net/starlarktest"
@@ -74,6 +75,7 @@ func (c *compiler) Compile(ctx context.Context, nv feature.NamespaceVersion) (*f
 		"feature": starlark.NewBuiltin("feature", makeFeature),
 		"proto":   protoModule,
 		"struct":  starlark.NewBuiltin("struct", starlarkstruct.Make),
+		"math":    math.Module,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "starlark execfile")


### PR DESCRIPTION
Allow for using math functions in starlark.
eg.
```
tier.discount_pricing = math.floor(tier.pricing * (1 - discountPercent) * 100) / 100  # round to two decimal places
```