### PR TITLE
Add CallExpression type to rules proto def

### DIFF
--- a/proto/lekko/rules/v1beta3/rules.proto
+++ b/proto/lekko/rules/v1beta3/rules.proto
@@ -89,22 +89,27 @@ enum LogicalOperator {
 }
 
 // CallExpression represents a function call, e.g. f(a, b, c).
-// Function calls can take an arbitrary number of args corresponding to their
-// implementation.
-// The specific function is represented by the FunctionId enum value.
+// Each function has a specific signature, so a CallExpression is
+// expressed as one of the different supported functions.
 message CallExpression {
-  FunctionId function_id = 1;
-  repeated CallExpressionArg args = 2;
-}
+  // Example signature
+  // message Example {
+  //   uint32 x = 1;
+  //   string y = 2;
+  // }
 
-// An argument to a CallExpression can either be a rule or an arbitrary value
-message CallExpressionArg {
-  oneof call_expression_arg {
-    Rule rule = 1;
-    google.protobuf.Value value = 2;
+  // Bucketing function for percentage-based context evaluation
+  message Bucket {
+    string context_key = 1;
+    // Threshold for dividing buckets.
+    // Stored as an integer in the range [0, 100000] instead of a double
+    // to avoid potential precision issues while supporting up to 3
+    // decimal places to users.
+    // e.g. threshold = 75125 -> 75.125%
+    uint32 threshold = 2;
   }
-}
 
-enum FunctionId {
-  FUNCTION_ID_UNSPECIFIED = 0;
+  oneof function {
+    Bucket bucket = 1;
+  }
 }


### PR DESCRIPTION
# Context
See relevant task: [Add CallExpression to ruleslang](https://www.notion.so/lekko/Add-CallExpression-to-ruleslang-6e682fb2a5004852a36603a9aa277c93)

# Details
The general idea is to introduce a new type of expression that can flexibly support rules with function calls. A `CallExpression` is an expression type that can be one of the supported UDF types, where their signatures are statically defined in a nested message.

A `Bucket` function type is introduced here, to be the first example and to be implemented in other components later.

Notes in terms of how this should be used:
- The rule parser (AST visitor) will be responsible for checking function names and arguments
- The rule evaluator will be responsible for the implementation of the functions' algorithms