### PR TITLE
Use external types

### DIFF
--- a/cmd/lekko/main.go
+++ b/cmd/lekko/main.go
@@ -130,7 +130,7 @@ func compileCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "parse metadata")
 			}
-			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory)
+			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory, rootMD.UseExternalTypes)
 			if err != nil {
 				return errors.Wrap(err, "rebuild type registry")
 			}
@@ -184,7 +184,7 @@ func verifyCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "parse metadata")
 			}
-			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory)
+			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory, rootMD.UseExternalTypes)
 			if err != nil {
 				return errors.Wrap(err, "rebuild type registry")
 			}
@@ -550,7 +550,7 @@ func restoreCmd() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "parse metadata")
 			}
-			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory)
+			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory, rootMD.UseExternalTypes)
 			if err != nil {
 				return errors.Wrap(err, "rebuild type registry")
 			}

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -41,9 +41,10 @@ import (
 // The type for
 type RootConfigRepoMetadata struct {
 	// This version refers to the version of the metadata.
-	Version        string   `json:"version,omitempty" yaml:"version,omitempty"`
-	Namespaces     []string `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
-	ProtoDirectory string   `json:"protoDir,omitempty" yaml:"protoDir,omitempty"`
+	Version          string   `json:"version,omitempty" yaml:"version,omitempty"`
+	Namespaces       []string `json:"namespaces,omitempty" yaml:"namespaces,omitempty"`
+	ProtoDirectory   string   `json:"protoDir,omitempty" yaml:"protoDir,omitempty"`
+	UseExternalTypes bool     `json:"externalTypes,omitempty" yaml:"externalTypes,omitempty"`
 }
 
 type NamespaceConfigRepoMetadata struct {

--- a/pkg/repo/feature.go
+++ b/pkg/repo/feature.go
@@ -46,7 +46,7 @@ type ConfigurationStore interface {
 	Compile(ctx context.Context, req *CompileRequest) ([]*FeatureCompilationResult, error)
 	Verify(ctx context.Context, req *VerifyRequest) error
 	BuildDynamicTypeRegistry(ctx context.Context, protoDirPath string) (*protoregistry.Types, error)
-	ReBuildDynamicTypeRegistry(ctx context.Context, protoDirPath string) (*protoregistry.Types, error)
+	ReBuildDynamicTypeRegistry(ctx context.Context, protoDirPath string, useExternalTypes bool) (*protoregistry.Types, error)
 	GetFileDescriptorSet(ctx context.Context, protoDirPath string) (*descriptorpb.FileDescriptorSet, error)
 	Format(ctx context.Context, verbose bool) error
 	AddFeature(ctx context.Context, ns, featureName string, fType feature.FeatureType, protoMessageName string) (string, error)
@@ -509,11 +509,11 @@ func (r *repository) BuildDynamicTypeRegistry(ctx context.Context, protoDirPath 
 // Note: we don't have a way yet to run this from an ephemeral repo,
 // because we need to first ensure that buf cmd line can be executed in the
 // ephemeral env.
-func (r *repository) ReBuildDynamicTypeRegistry(ctx context.Context, protoDirPath string) (*protoregistry.Types, error) {
+func (r *repository) ReBuildDynamicTypeRegistry(ctx context.Context, protoDirPath string, useExternalTypes bool) (*protoregistry.Types, error) {
 	if !r.bufEnabled {
 		return nil, errors.New("buf cmd line not enabled")
 	}
-	sTypes, err := prototypes.ReBuildDynamicTypeRegistry(ctx, protoDirPath, r)
+	sTypes, err := prototypes.ReBuildDynamicTypeRegistry(ctx, protoDirPath, useExternalTypes, r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/star/prototypes/proto.go
+++ b/pkg/star/prototypes/proto.go
@@ -61,7 +61,12 @@ func BuildDynamicTypeRegistry(ctx context.Context, protoDir string, provider fs.
 }
 
 // Note: this method is not safe to be run on ephemeral repos, as it invokes the buf cmd line.
-func ReBuildDynamicTypeRegistry(ctx context.Context, protoDir string, cw fs.ConfigWriter) (*SerializableTypes, error) {
+func ReBuildDynamicTypeRegistry(ctx context.Context, protoDir string, useExternalTypes bool, cw fs.ConfigWriter) (*SerializableTypes, error) {
+	if useExternalTypes {
+		// If using external types, don't rebuild the protobuf file descriptor set because
+		// it was imported from elsewhere. Simply use it.
+		return BuildDynamicTypeRegistry(ctx, protoDir, cw)
+	}
 	if err := checkBufExists(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow using external types with a new field in the root metadata file `lekko.root.yaml`:

```yaml
externalTypes: true
```