### PR TITLE
Implement bucket rule evaluation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	buf.build/gen/go/lekkodev/cli/bufbuild/connect-go v1.8.0-20230614183715-890c7a85aff8.1
 	buf.build/gen/go/lekkodev/cli/protocolbuffers/go v1.30.0-20230614183715-890c7a85aff8.1
 	github.com/AlecAivazis/survey/v2 v2.3.6
+	github.com/OneOfOne/xxhash v1.2.8
 	github.com/bazelbuild/buildtools v0.0.0-20220907133145-b9bfff5d7f91
 	github.com/bufbuild/connect-go v1.8.0
 	github.com/cli/browser v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
+github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=

--- a/pkg/rules/functions.go
+++ b/pkg/rules/functions.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	rulesv1beta3 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/rules/v1beta3"
+	"github.com/OneOfOne/xxhash"
+	"github.com/pkg/errors"
+)
+
+// If the hashed feature value % 100 <= threshold, it fits in the "bucket".
+// In reality, we internally store the threshold as an integer in [0,100000]
+// to account for up to 3 decimal places.
+// The feature value is salted using the namespace, feature name, and context key.
+func (v1b3 *v1beta3) evaluateBucket(bucketF *rulesv1beta3.CallExpression_Bucket, featureCtx map[string]interface{}) (bool, error) {
+	ctxKey := bucketF.ContextKey
+	value, present := featureCtx[ctxKey]
+	// If key is missing in context map, evaluate to false - move to next rule
+	if !present {
+		return false, nil
+	}
+	var valueBytes []byte
+	var err error
+	bytesBuffer := new(bytes.Buffer)
+	switch typedValue := value.(type) {
+	case int:
+		err = binary.Write(bytesBuffer, binary.BigEndian, int64(typedValue))
+	case int8:
+		err = binary.Write(bytesBuffer, binary.BigEndian, int64(typedValue))
+	case int16:
+		err = binary.Write(bytesBuffer, binary.BigEndian, int64(typedValue))
+	case int32:
+		err = binary.Write(bytesBuffer, binary.BigEndian, int64(typedValue))
+	case int64:
+		err = binary.Write(bytesBuffer, binary.BigEndian, typedValue)
+	case float32:
+		err = binary.Write(bytesBuffer, binary.BigEndian, float64(typedValue))
+	case float64:
+		err = binary.Write(bytesBuffer, binary.BigEndian, typedValue)
+	case string:
+		valueBytes = []byte(typedValue)
+	default:
+		return false, errors.Errorf("unsupported value type for bucket: %T", value)
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if len(valueBytes) == 0 {
+		valueBytes = bytesBuffer.Bytes()
+	}
+
+	bytesFrags := [][]byte{
+		[]byte(v1b3.evalContext.Namespace),
+		[]byte(v1b3.evalContext.FeatureName),
+		[]byte(ctxKey),
+		valueBytes,
+	}
+
+	// Hash namespace -> feature name -> context key -> value
+	hash := xxhash.NewS32(0)
+	for _, bytesFrag := range bytesFrags {
+		_, err := hash.Write(bytesFrag)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return hash.Sum32()%100000 <= bucketF.Threshold, nil
+}

--- a/pkg/rules/functions_test.go
+++ b/pkg/rules/functions_test.go
@@ -1,0 +1,195 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rules
+
+import (
+	"testing"
+
+	rulesv1beta3 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/rules/v1beta3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testEvalCtxs []EvalContext = []EvalContext{
+	{
+		Namespace:   "ns_1",
+		FeatureName: "feature_1",
+	},
+	{
+		Namespace:   "ns_2",
+		FeatureName: "feature_2",
+	},
+}
+
+// NOTE: to test consistency of the hashing/bucketing algorithms cross-platform
+// test cases (data and expected evaluation results) should be identical
+func testBucket[K comparable](t *testing.T, testCases []map[K]bool) {
+	for eIdx, evalCtx := range testEvalCtxs {
+		for ctxValue, expected := range testCases[eIdx] {
+			rule := NewV1Beta3(
+				&rulesv1beta3.Rule{
+					Rule: &rulesv1beta3.Rule_CallExpression{
+						CallExpression: &rulesv1beta3.CallExpression{
+							Function: &rulesv1beta3.CallExpression_Bucket_{
+								// 50% bucketing
+								Bucket: &rulesv1beta3.CallExpression_Bucket{
+									ContextKey: "key",
+									Threshold:  50000,
+								},
+							},
+						},
+					},
+				},
+				evalCtx,
+			)
+
+			featureCtx := map[string]interface{}{
+				"key": ctxValue,
+			}
+
+			result, err := rule.EvaluateRule(featureCtx)
+
+			require.NoError(t, err)
+			assert.Equal(
+				t,
+				expected,
+				result,
+				"Unexpected bucket result for %v/%v/%v:%v: expected %v, got %v",
+				evalCtx.Namespace,
+				evalCtx.FeatureName,
+				"key",
+				ctxValue,
+				expected,
+				result,
+			)
+		}
+	}
+}
+
+func TestBucketUnsupported(t *testing.T) {
+	rule := NewV1Beta3(
+		&rulesv1beta3.Rule{
+			Rule: &rulesv1beta3.Rule_CallExpression{
+				CallExpression: &rulesv1beta3.CallExpression{
+					Function: &rulesv1beta3.CallExpression_Bucket_{
+						Bucket: &rulesv1beta3.CallExpression_Bucket{
+							ContextKey: "key",
+							Threshold:  50000,
+						},
+					},
+				},
+			},
+		},
+		testEvalCtxs[0],
+	)
+
+	// Context with unsupported value type for bucket bool
+	featureCtx := map[string]interface{}{
+		"key": false,
+	}
+
+	_, err := rule.EvaluateRule(featureCtx)
+	require.Error(t, err, "Expected error for unsupported type for bucketing")
+}
+
+func TestBucketInts(t *testing.T) {
+	testCases := []map[int]bool{
+		{
+			1:   false,
+			2:   false,
+			3:   true,
+			4:   false,
+			5:   true,
+			101: true,
+			102: true,
+			103: false,
+			104: false,
+			105: true,
+		},
+		{
+			1:   false,
+			2:   true,
+			3:   false,
+			4:   false,
+			5:   true,
+			101: true,
+			102: true,
+			103: false,
+			104: true,
+			105: true,
+		},
+	}
+	testBucket[int](t, testCases)
+}
+
+func TestBucketDoubles(t *testing.T) {
+	testCases := []map[float64]bool{
+		{
+			3.1415: false,
+			2.7182: false,
+			1.6180: true,
+			6.6261: true,
+			6.0221: false,
+			2.9979: true,
+			6.6730: false,
+			1.3807: true,
+			1.4142: true,
+			2.0000: false,
+		},
+		{
+			3.1415: true,
+			2.7182: false,
+			1.6180: true,
+			6.6261: false,
+			6.0221: false,
+			2.9979: false,
+			6.6730: false,
+			1.3807: false,
+			1.4142: true,
+			2.0000: false,
+		},
+	}
+	testBucket[float64](t, testCases)
+}
+
+func TestBucketStrings(t *testing.T) {
+	testCases := []map[string]bool{
+		{
+			"hello":  false,
+			"world":  false,
+			"i":      true,
+			"am":     true,
+			"a":      true,
+			"unit":   false,
+			"test":   true,
+			"case":   true,
+			"for":    false,
+			"bucket": false,
+		},
+		{
+			"hello":  true,
+			"world":  false,
+			"i":      true,
+			"am":     true,
+			"a":      true,
+			"unit":   false,
+			"test":   true,
+			"case":   false,
+			"for":    false,
+			"bucket": false,
+		},
+	}
+	testBucket[string](t, testCases)
+}

--- a/pkg/rules/v1beta3.go
+++ b/pkg/rules/v1beta3.go
@@ -117,6 +117,11 @@ func (v1b3 *v1beta3) evaluateRule(rule *rulesv1beta3.Rule, featureCtx map[string
 		case rulesv1beta3.ComparisonOperator_COMPARISON_OPERATOR_CONTAINS:
 			return v1b3.evaluateStringComparator(r.Atom.ComparisonOperator, r.Atom.GetComparisonValue(), runtimeCtxVal)
 		}
+	case *rulesv1beta3.Rule_CallExpression:
+		switch f := r.CallExpression.Function.(type) {
+		case *rulesv1beta3.CallExpression_Bucket_:
+			return v1b3.evaluateBucket(f.Bucket, featureCtx)
+		}
 	}
 	return false, errors.Errorf("unknown rule type %T", rule.Rule)
 }


### PR DESCRIPTION
# Context
See overall [task](https://www.notion.so/lekko/Implement-bucket-function-rule-evaluation-6c795242061e4fdba3ed4717d369d491?pvs=4)

We want to introduce a percentage-based bucketing function as a new rule which hashes the context value and checks against the user-specified threshold to bucket values into true/false. The changes here build on/mirror previous changes in ruleslang and sidecar.

# Details
- Added github.com/OneOfOne/xxhash as a dependency
    - Tested against `xxhash-rust`, the cargo used in sidecar, for cross-platform correctness
- Added `evaluateBucket` which implements the bucketing algorithm
- Added unit tests
    - Unit tests are basically mirrored with the Rust tests (same keys/values), confirming consistent bucketing behavior