### PR TITLE
Add fetching emails for commit author identity

### DIFF
--- a/pkg/gh/github.go
+++ b/pkg/gh/github.go
@@ -61,6 +61,14 @@ func (gc *GithubClient) GetUser(ctx context.Context) (*github.User, error) {
 	return user, nil
 }
 
+func (gc *GithubClient) GetUserEmails(ctx context.Context) ([]*github.UserEmail, error) {
+	emails, _, err := gc.Users.ListEmails(ctx, nil)
+	if err != nil {
+		return nil, errors.New(SanitizedErrorMessage(err))
+	}
+	return emails, nil
+}
+
 // Init will create a new github repo based off of lekko's config repo template.
 func (gc *GithubClient) Init(ctx context.Context, owner, repoName string, private bool) (string, error) {
 	repo, resp, err := gc.Repositories.Get(ctx, owner, repoName)


### PR DESCRIPTION
# Context
We want to include identifiable information in generated commits.

With the way GitHub's API works, a `GET /user` call does not necessarily include email addresses if the user has email settings set to private (even if the auth token has permissions to read emails). For this case, we want to make a separate `GET /user/email` call to get email addresses.

# Details
- Add client call to GitHub's `GET /user/email`
- Update commit method to include primary email address