### PR TITLE
Fix commits failing for users with private email settings on for GitHub

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -401,11 +401,16 @@ func (r *repository) Commit(ctx context.Context, ap AuthProvider, message string
 		// but don't fail loudly if we fail to fetch (could be due to app permissions, etc.)
 		if emails, err := ghCli.GetUserEmails(ctx); err == nil {
 			for _, fetchedEmail := range emails {
-				if fetchedEmail.Primary != nil && *fetchedEmail.Primary {
-					email = *fetchedEmail.Email
+				if fetchedEmail.GetPrimary() && fetchedEmail.GetVisibility() == "public" {
+					email = fetchedEmail.GetEmail()
 					break
 				}
 			}
+		}
+		// Use GitHub's noreply email as fallback
+		// https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address
+		if email == "" {
+			email = fmt.Sprintf("%d+%s@users.noreply.github.com", *user.ID, *user.Login)
 		}
 	}
 


### PR DESCRIPTION
# Context
Users can set their email addresses to private (which is different from "not public") on GitHub, and block any pushes that might expose private email addresses. For this case, we want to use the noreply GitHub user email (which still allows linking the commit author identity to the correct GitHub user) as a fallback.

# Details
- Added check for visibility of emails and use noreply email address as fallback