### PR TITLE
Update some error messages with rules -> overrides

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -757,7 +757,7 @@ type ValidatorResultType int
 
 const (
 	ValidatorResultTypeDefault ValidatorResultType = iota
-	ValidatorResultTypeRule
+	ValidatorResultTypeOverride
 	ValidatorResultTypeTest
 )
 
@@ -791,8 +791,8 @@ func (vr *ValidatorResult) WithError(err error) *ValidatorResult {
 
 func (vr *ValidatorResult) Identifier() string {
 	prefix := "validate default"
-	if vr.Type == ValidatorResultTypeRule {
-		prefix = fmt.Sprintf("validate rule %d", vr.Index)
+	if vr.Type == ValidatorResultTypeOverride {
+		prefix = fmt.Sprintf("validate override %d", vr.Index)
 	}
 	end := 25
 	if len(vr.Value) < end {

--- a/pkg/star/feature.go
+++ b/pkg/star/feature.go
@@ -144,7 +144,7 @@ func (fb *featureBuilder) Build() (*feature.CompiledFeature, error) {
 	if fb.validator != nil {
 		validatorResults = append(validatorResults, fb.validate(feature.ValidatorResultTypeDefault, 0, defaultVal))
 		for idx, ov := range overrideVals {
-			validatorResults = append(validatorResults, fb.validate(feature.ValidatorResultTypeRule, idx, ov))
+			validatorResults = append(validatorResults, fb.validate(feature.ValidatorResultTypeOverride, idx, ov))
 		}
 	}
 
@@ -534,7 +534,7 @@ func translateContext(dict *starlark.Dict) (map[string]interface{}, error) {
 }
 
 func typeError(expectedType eval.FeatureType, ruleIdx int, value starlark.Value) error {
-	return fmt.Errorf("expecting %s for rule idx #%d, instead got %T", starType(expectedType), ruleIdx, value)
+	return fmt.Errorf("expecting %s for value of override idx #%d, instead got %T", starType(expectedType), ruleIdx, value)
 }
 
 func starType(ft eval.FeatureType) string {

--- a/pkg/star/static/traverse.go
+++ b/pkg/star/static/traverse.go
@@ -197,7 +197,7 @@ func (ast *starFeatureAST) parseOverrides(fn overridesFn) error {
 		for i, elemV := range listV.List {
 			o, err := newOverride(elemV)
 			if err != nil {
-				return errors.Wrapf(err, "rule %d", i)
+				return errors.Wrapf(err, "override %d", i)
 			}
 			overridesW.overrides = append(overridesW.overrides, *o)
 		}

--- a/pkg/star/static/walk.go
+++ b/pkg/star/static/walk.go
@@ -493,7 +493,7 @@ func (w *walker) mutateOverridesFn(f *featurev1beta1.StaticFeature) overridesFn 
 			}
 			gen, err := w.genValue(r.Value, f, meta)
 			if err != nil {
-				return errors.Wrapf(err, "rule %d: gen value", i)
+				return errors.Wrapf(err, "override %d: gen value", i)
 			}
 			newRuleString := r.Rule
 			if r.RuleAstNew != nil {


### PR DESCRIPTION
# Context
Follow-up from #233, updating some missed error messages to use overrides instead of rules.