### PR TITLE
Update CLI output messages to use new config vocabulary

### DIFF
--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -48,6 +48,6 @@ func ParseFeature(ctx context.Context, rootPath string, featureFile feature.Feat
 		}
 		return eval.NewV1Beta3(&f, nsMD.Name), nil
 	default:
-		return nil, fmt.Errorf("unknown version when parsing feature: %s", nsMD.Version)
+		return nil, fmt.Errorf("unknown version when parsing config: %s", nsMD.Version)
 	}
 }

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -69,16 +69,16 @@ type FeatureContents struct {
 
 func (ff FeatureFile) Verify() error {
 	if ff.Name == "" {
-		return fmt.Errorf("feature file has no name")
+		return fmt.Errorf("config file has no name")
 	}
 	if ff.StarlarkFileName == "" {
-		return fmt.Errorf("feature file %s has no .star file", ff.Name)
+		return fmt.Errorf("config file %s has no .star file", ff.Name)
 	}
 	if ff.CompiledJSONFileName == "" {
-		return fmt.Errorf("feature file %s has no .json file", ff.Name)
+		return fmt.Errorf("config file %s has no .json file", ff.Name)
 	}
 	if ff.CompiledProtoBinFileName == "" {
-		return fmt.Errorf("feature file %s has no .proto.bin file", ff.Name)
+		return fmt.Errorf("config file %s has no .proto.bin file", ff.Name)
 	}
 	return nil
 }
@@ -177,13 +177,13 @@ func ComplianceCheck(f FeatureFile, nsMD *metadata.NamespaceConfigRepoMetadata) 
 		fallthrough
 	case "v1beta3":
 		if len(f.CompiledJSONFileName) == 0 {
-			return fmt.Errorf("empty compiled JSON for feature: %s", f.Name)
+			return fmt.Errorf("empty compiled JSON for config: %s", f.Name)
 		}
 		if len(f.CompiledProtoBinFileName) == 0 {
-			return fmt.Errorf("empty compiled proto for feature: %s", f.Name)
+			return fmt.Errorf("empty compiled proto for config: %s", f.Name)
 		}
 		if len(f.StarlarkFileName) == 0 {
-			return fmt.Errorf("empty starlark file for feature: %s", f.Name)
+			return fmt.Errorf("empty starlark file for config: %s", f.Name)
 		}
 	}
 	return nil
@@ -197,7 +197,7 @@ func ParseFeaturePath(featurePath string) (namespaceName string, featureName str
 	if len(splits) == 2 {
 		return splits[0], splits[1], nil
 	}
-	return "", "", fmt.Errorf("invalid featurepath: %s, should be of format namespace[/feature]", featurePath)
+	return "", "", fmt.Errorf("invalid config path: %s, should be of format namespace[/config]", featurePath)
 }
 
 var ErrTypeMismatch = fmt.Errorf("type mismatch")
@@ -335,7 +335,7 @@ func (ut ValueUnitTest) Run(idx int, eval eval.EvaluableFeature) *TestResult {
 	tr := NewTestResult(ut.ContextStar, idx)
 	a, _, err := eval.Evaluate(ut.Context)
 	if err != nil {
-		return tr.WithError(errors.Wrap(err, "evaluate feature"))
+		return tr.WithError(errors.Wrap(err, "evaluate config"))
 	}
 
 	val, err := ValToAny(ut.ExpectedValue, eval.Type())
@@ -455,7 +455,7 @@ func ValToAny(value interface{}, ft eval.FeatureType) (*anypb.Any, error) {
 		}
 		return newAny(v)
 	default:
-		return nil, fmt.Errorf("unsupported feature type %T", value)
+		return nil, fmt.Errorf("unsupported config type %T", value)
 	}
 }
 
@@ -511,7 +511,7 @@ func AnyToVal(a *anypb.Any, fType eval.FeatureType, registry *protoregistry.Type
 		}
 		return p.ProtoReflect(), nil
 	default:
-		return nil, fmt.Errorf("unsupported feature type %s", a.TypeUrl)
+		return nil, fmt.Errorf("unsupported config type %s", a.TypeUrl)
 	}
 }
 
@@ -667,7 +667,7 @@ func ProtoToJSON(fProto *featurev1beta1.Feature, registry *protoregistry.Types) 
 func (f *Feature) ToJSON(registry *protoregistry.Types) ([]byte, error) {
 	fProto, err := f.ToProto()
 	if err != nil {
-		return nil, errors.Wrap(err, "feature to proto")
+		return nil, errors.Wrap(err, "config to proto")
 	}
 	return ProtoToJSON(fProto, registry)
 }
@@ -675,7 +675,7 @@ func (f *Feature) ToJSON(registry *protoregistry.Types) ([]byte, error) {
 func (f *Feature) PrintJSON(registry *protoregistry.Types) {
 	jBytes, err := f.ToJSON(registry)
 	if err != nil {
-		fmt.Printf("failed to convert feature to json: %v\n", err)
+		fmt.Printf("failed to convert config to json: %v\n", err)
 	}
 	fmt.Println(string(jBytes))
 }
@@ -740,7 +740,7 @@ func (tr *TestResult) DebugString() string {
 func (f *Feature) RunUnitTests() ([]*TestResult, error) {
 	eval, err := f.ToEvaluableFeature()
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid feature")
+		return nil, errors.Wrap(err, "invalid config")
 	}
 	var results []*TestResult
 	for idx, test := range f.UnitTests {

--- a/pkg/k8s/apply.go
+++ b/pkg/k8s/apply.go
@@ -128,7 +128,7 @@ func (k *kubeClient) List(ctx context.Context) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-	fmt.Fprintf(w, "k8s Namespace\tLekko Namespace\tFeature Name\tSize\n")
+	fmt.Fprintf(w, "k8s Namespace\tLekko Namespace\tConfig Name\tSize\n")
 	for _, item := range result.Items {
 		for featureName, featureBytes := range item.BinaryData {
 			fmt.Fprintf(w, "%s\t%s\t%s\t[%d bytes]\n", item.GetNamespace(), item.GetName(), featureName, len(featureBytes))
@@ -188,7 +188,7 @@ func (k *kubeClient) applyLekkoNamespace(
 	cm := corev1.ConfigMap(cmName, k.k8sNamespace)
 	ffs, err := k.r.GetFeatureFiles(ctx, namespaceName)
 	if err != nil {
-		return fmt.Errorf("get feature files: %w", err)
+		return fmt.Errorf("get config files: %w", err)
 	}
 	for _, ff := range ffs {
 		bytes, err := k.r.GetFileContents(ctx, ff.RootPath(ff.CompiledProtoBinFileName))
@@ -209,6 +209,6 @@ func (k *kubeClient) applyLekkoNamespace(
 	if err != nil {
 		return errors.Wrap(err, "cm apply")
 	}
-	fmt.Printf("successfully applied configmap '%s' with %d features\n", result.Name, len(result.BinaryData))
+	fmt.Printf("successfully applied configmap '%s' with %d configs\n", result.Name, len(result.BinaryData))
 	return nil
 }

--- a/pkg/repo/repo_integration_test.go
+++ b/pkg/repo/repo_integration_test.go
@@ -117,7 +117,7 @@ func testReview(ctx context.Context, t *testing.T, r *repository, ghCli *gh.Gith
 		}
 		path, err := r.AddFeature(ctx, namespace, getFeatureName(fType), eval.FeatureType(fType), protoMessageName)
 		require.NoError(t, err)
-		t.Logf("wrote feature to path %s\n", path)
+		t.Logf("wrote config to path %s\n", path)
 	}
 	// Compile
 	rootMD, _, err := r.ParseMetadata(ctx)

--- a/pkg/star/compile.go
+++ b/pkg/star/compile.go
@@ -102,7 +102,7 @@ func (c *compiler) Compile(ctx context.Context, nv feature.NamespaceVersion) (*f
 func (c *compiler) Persist(ctx context.Context, f *feature.Feature, nv feature.NamespaceVersion, ignoreBackwardsCompatibility, dryRun bool) (bool, bool, error) {
 	fProto, err := f.ToProto()
 	if err != nil {
-		return false, false, errors.Wrap(err, "feature to proto")
+		return false, false, errors.Wrap(err, "config to proto")
 	}
 	jsonGenPath := filepath.Join(c.ff.NamespaceName, metadata.GenFolderPathJSON)
 	protoGenPath := filepath.Join(c.ff.NamespaceName, metadata.GenFolderPathProto)
@@ -157,11 +157,11 @@ func compareExistingProto(ctx context.Context, existingProtoFilePath string, new
 		return false, errors.Wrap(err, fmt.Sprintf("failed to unmarshal existing proto at path %s", existingProtoFilePath))
 	}
 	if existingProto.GetKey() != newProto.GetKey() {
-		return true, fmt.Errorf("cannot change key of feature flag: old %s, new %s", existingProto.GetKey(), newProto.GetKey())
+		return true, fmt.Errorf("cannot change key of config: old %s, new %s", existingProto.GetKey(), newProto.GetKey())
 	}
 	if existingProto.GetTree().GetDefault().GetTypeUrl() != newProto.GetTree().GetDefault().GetTypeUrl() {
 		return true, fmt.Errorf(
-			"cannot change feature flag type: old %s, new %s",
+			"cannot change config type: old %s, new %s",
 			existingProto.GetTree().GetDefault().GetTypeUrl(),
 			newProto.GetTree().GetDefault().GetTypeUrl(),
 		)

--- a/pkg/star/feature.go
+++ b/pkg/star/feature.go
@@ -72,14 +72,14 @@ func allowedAttrNames() []string {
 
 func makeFeature(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) > 0 {
-		return nil, fmt.Errorf("feature: unexpected positional arguments")
+		return nil, fmt.Errorf("config: unexpected positional arguments")
 	}
 	return starlarkstruct.FromKeywords(FeatureConstructor, kwargs), nil
 }
 
 func makeConfig(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	if len(args) > 0 {
-		return nil, fmt.Errorf("feature: unexpected positional arguments")
+		return nil, fmt.Errorf("config: unexpected positional arguments")
 	}
 	return starlarkstruct.FromKeywords(ConfigConstructor, kwargs), nil
 }
@@ -132,7 +132,7 @@ func (fb *featureBuilder) Build() (*feature.CompiledFeature, error) {
 		return nil, fmt.Errorf("expecting variable of type %s, instead got %T", ConfigConstructor.GoString(), featureVal)
 	}
 	if err := fb.validateFeature(featureVal); err != nil {
-		return nil, errors.Wrap(err, "validate feature")
+		return nil, errors.Wrap(err, "validate config")
 	}
 	var err error
 	fb.validator, err = fb.getValidator(featureVal)
@@ -145,7 +145,7 @@ func (fb *featureBuilder) Build() (*feature.CompiledFeature, error) {
 	}
 	f, err := fb.init(defaultVal)
 	if err != nil {
-		return nil, errors.Wrap(err, "initialize feature")
+		return nil, errors.Wrap(err, "initialize config")
 	}
 	f.Key = fb.featureName
 	f.Description, err = fb.getDescription(featureVal)

--- a/pkg/star/static/testdata/map.star
+++ b/pkg/star/static/testdata/map.star
@@ -3,7 +3,7 @@ tpb = proto.package("testproto.v1beta1")
 
 export(
     Config(
-        description = "map feature for testing",
+        description = "map config for testing",
         default = tpb.MapFields(
             strings = {
                 "foo": "bar",

--- a/pkg/star/static/testdata/nested.star
+++ b/pkg/star/static/testdata/nested.star
@@ -3,7 +3,7 @@ tpb = proto.package("testproto.v1beta1")
 
 export(
     Config(
-        description = "nested feature for testing",
+        description = "nested config for testing",
         default = tpb.MultiLevel(
             primitive = "foo",
             sub_message = tpb.TestMessage(

--- a/pkg/star/static/testdata/repeated.star
+++ b/pkg/star/static/testdata/repeated.star
@@ -3,7 +3,7 @@ tpb = proto.package("testproto.v1beta1")
 
 export(
     Config(
-        description = "repeated feature for testing",
+        description = "repeated config for testing",
         default = tpb.RepeatedFields(
             vals = [
                 "d",

--- a/pkg/star/static/traverse.go
+++ b/pkg/star/static/traverse.go
@@ -269,7 +269,7 @@ func (t *traverser) getFeatureAST() (*starFeatureAST, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("no feature found in star file")
+	return nil, fmt.Errorf("no config found in star file")
 }
 
 func (t *traverser) getProtoImports() *importsWrapper {

--- a/pkg/star/static/walk.go
+++ b/pkg/star/static/walk.go
@@ -255,7 +255,7 @@ func (w *walker) buildRulesFn(f *featurev1beta1.StaticFeature) overridesFn {
 			}
 			overrideVal, err := w.toAny(protoVal)
 			if err != nil {
-				return errors.Wrapf(err, "extracted proto val to any for feature type %v", featureType)
+				return errors.Wrapf(err, "extracted proto val to any for config type %v", featureType)
 			}
 			override.Value = overrideVal
 			f.FeatureOld.Tree.Constraints = append(f.FeatureOld.Tree.Constraints, override)
@@ -464,7 +464,7 @@ func (w *walker) mutateDefaultFn(f *featurev1beta1.StaticFeature) defaultFn {
 			return errors.Wrap(err, "extract default value")
 		}
 		if featureType != f.Type {
-			return errors.Wrapf(err, "cannot mutate star feature type %v with arg feature type %v", featureType, f.Type)
+			return errors.Wrapf(err, "cannot mutate star config type %v with arg config type %v", featureType, f.Type)
 		}
 		gen, err := w.genValue(f.FeatureOld.Tree.Default, f, f.GetFeature().GetDefault().GetMeta())
 		if err != nil {

--- a/pkg/star/static/walk_test.go
+++ b/pkg/star/static/walk_test.go
@@ -69,7 +69,7 @@ func typedVals(t *testing.T, ft eval.FeatureType, indent string) (defaultVal tes
         %[1]s}`, indent)
 		return testVal{goVal, "[\"foo\", 1, 2, 4.2]"}, testVal{ruleVal, ruleStarVal}
 	}
-	t.Fatalf("unsupported feature type %s", ft)
+	t.Fatalf("unsupported config type %s", ft)
 	return
 }
 
@@ -82,7 +82,7 @@ func testStar(t *testing.T, ft eval.FeatureType, useExport bool) (testVal, []byt
 	if useExport {
 		return val, []byte(fmt.Sprintf(`export(
     Config(
-        description = "this is a simple feature",
+        description = "this is a simple config",
         default = %s,
         rules = [
             ("age == 10", %s),
@@ -93,7 +93,7 @@ func testStar(t *testing.T, ft eval.FeatureType, useExport bool) (testVal, []byt
 `, val.starRepr, ruleVal.starRepr, ruleVal.starRepr))
 	} else {
 		return val, []byte(fmt.Sprintf(`result = feature(
-    description = "this is a simple feature",
+    description = "this is a simple config",
     default = %s,
     rules = [
         ("age == 10", %s),
@@ -242,7 +242,7 @@ func TestWalkerMutateAddFirstOverride(t *testing.T) {
 	starBytes := []byte(fmt.Sprintf(`
 		export(
 			Config(
-				description = "this is a simple feature",
+				description = "this is a simple config",
 				default = %s,
 			),
 		)
@@ -295,7 +295,7 @@ func TestWalkerMutateRemoveOnlyOverride(t *testing.T) {
 	starBytes := []byte(fmt.Sprintf(`
 		export(
 			Config(
-				description = "this is a simple feature",
+				description = "this is a simple config",
 				default = %s,
 				rules = [
 					("age == 10", %s),
@@ -325,11 +325,11 @@ func TestWalkerMutateDescription(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, f)
 
-				f.FeatureOld.Description = "a NEW way to describe this feature."
+				f.FeatureOld.Description = "a NEW way to describe this config."
 
 				bytes, err := b.Mutate(f)
 				require.NoError(t, err)
-				assert.Contains(t, string(bytes), "a NEW way to describe this feature.")
+				assert.Contains(t, string(bytes), "a NEW way to describe this config.")
 			}
 		})
 	}
@@ -496,7 +496,7 @@ func TestWalkerProto(t *testing.T) {
 			tpb = proto.package("testproto.v1beta1")
 			export(
 				Config(
-					description = "proto feature",
+					description = "proto config",
 					default = %s,
 					rules = [("age > 1", %s)]
 				),

--- a/pkg/star/templates.go
+++ b/pkg/star/templates.go
@@ -80,6 +80,6 @@ func GetTemplate(fType eval.FeatureType) ([]byte, error) {
 	case eval.FeatureTypeJSON:
 		return []byte(fmt.Sprintf(starFmt, "{}")), nil
 	default:
-		return nil, fmt.Errorf("templating is not supported for feature type %s", fType)
+		return nil, fmt.Errorf("templating is not supported for config type %s", fType)
 	}
 }


### PR DESCRIPTION
# Context
Since we updated commands and starlark syntax to use "config" instead of "feature", the CLI's outputs need to be updated as well.

# Details
- Took a pass through codebase with a simple regex search to try to find all instances of output/error messages that use the term "feature" and replaced appropriate ones with "config"
    - There's a small chance some might have been missed, but this should handle most of them
    - Updates outputs, errors, help messages, etc.

# Testing
- Compile with `go build ./cmd/lekko` and tested locally, didn't find any more messages with feature

Example output:
```
~/dev/cli/lekko compile
Found 8 configs across 1 namespaces
Compiling...
+-----------+--------------------+----------+--------+-------+------------+-----------+
| NAMESPACE |       CONFIG       | COMPILED |  TYPE  | TESTS | VALIDATORS | PERSISTED |
+-----------+--------------------+----------+--------+-------+------------+-----------+
| default   | bucket             | ✔        | int    | -     | -          | ✔         |
| default   | complex_constraint | ✔        | int    | -     | -          | ✔         |
| default   | example            | ✔        | bool   | -     | -          | ✔         |
| default   | history_feature    | ✔        | int    | -     | -          | ✔         |
| default   | json               | ✔        | json   | -     | -          | ✔         |
| default   | proto_test         | ✔        | proto  | -     | -          | ✔         |
| default   | string             | ✔        | string | -     | -          | ✔         |
| default   | test_add           | ✔        | string | -     | -          | ✖         |
+-----------+--------------------+----------+--------+-------+------------+-----------+
[default/test_add]
        [persistence] → comparing with existing proto: cannot change config type: old type.googleapis.com/google.protobuf.Int64Value, new type.googleapis.com/google.protobuf.StringValue
compile: comparing with existing proto: cannot change config type: old type.googleapis.com/google.protobuf.Int64Value, new type.googleapis.com/google.protobuf.StringValue
```