### PR TITLE
Revert config template to use old syntax

### DIFF
--- a/pkg/star/templates.go
+++ b/pkg/star/templates.go
@@ -23,8 +23,8 @@ import (
 )
 
 const starFmt = `result = feature(
-	description="my config description",
-	default=%s
+    description="my config description",
+    default=%s
 )
 `
 
@@ -42,12 +42,12 @@ const protoFeatureTemplate = `{{- range $name, $alias := .Packages }}
 {{- end}}
 
 result = feature(
-	description = "my config description",
-	default = {{.Message}}(
-		{{- range .Fields}}
-		{{. -}},
-		{{- end}}
-	),
+    description = "my config description",
+    default = {{.Message}}(
+        {{- range .Fields}}
+        {{. -}},
+        {{- end}}
+    ),
 )
 `
 

--- a/pkg/star/testdata/test_render_existing_proto_template.star
+++ b/pkg/star/testdata/test_render_existing_proto_template.star
@@ -2,16 +2,14 @@
 google_protobuf = proto.package("google.protobuf")
 internal_config_v1beta1 = proto.package("internal.config.v1beta1")
 
-export(
-    Config(
-        description = "my config description",
-        default = internal_config_v1beta1.ProductMetadata(
-            state = internal_config_v1beta1.ProductState.PRODUCT_STATE_UNSPECIFIED,
-            description = "",
-            time = google_protobuf.Timestamp(),
-            friend = internal_config_v1beta1.Friend(),
-            build = internal_config_v1beta1.Build(),
-            sell = internal_config_v1beta1.Sell(),
-        ),
+result = feature(
+    description = "my config description",
+    default = internal_config_v1beta1.ProductMetadata(
+        state = internal_config_v1beta1.ProductState.PRODUCT_STATE_UNSPECIFIED,
+        description = "",
+        time = google_protobuf.Timestamp(),
+        friend = internal_config_v1beta1.Friend(),
+        build = internal_config_v1beta1.Build(),
+        sell = internal_config_v1beta1.Sell(),
     ),
 )


### PR DESCRIPTION
# Context
Temporary fix for forward breaking change as a result of feature -> config syntax change.

Follow-up: introduce new namespace version to define support

# Testing
- Local build of CLI, run `lekko feature add` to verify new config uses old syntax
- Update dependencies in core and test on UI to verify new config uses old syntax