### PR TITLE
Simplify upgrade

### DIFF
--- a/cmd/lekko/main.go
+++ b/cmd/lekko/main.go
@@ -15,15 +15,11 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	bffv1beta1 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/bff/v1beta1"
 	"github.com/AlecAivazis/survey/v2"
@@ -586,92 +582,27 @@ func restoreCmd() *cobra.Command {
 }
 
 func upgradeCmd() *cobra.Command {
-	var apikey string
-	type execReq struct {
-		stdout, stderr io.Writer
-		env            []string
-		verbose        bool
-	}
-	execCmd := func(ctx context.Context, req *execReq, name string, args ...string) ([]byte, error) {
-		cmd := exec.CommandContext(ctx, name, args...)
-		stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
-		if req.stdout != nil {
-			cmd.Stdout = req.stdout
-		} else {
-			cmd.Stdout = stdout
-		}
-		if req.stderr != nil {
-			cmd.Stderr = req.stderr
-		} else {
-			cmd.Stderr = stderr
-		}
-		cmd.Env = append(cmd.Env, req.env...)
-		if req.verbose {
-			fmt.Printf("Running '%s %s'...\n", name, strings.Join(args, " "))
-		}
-		err := cmd.Run()
-		if err != nil {
-			return nil, errors.Wrapf(err, "%s %s", name, strings.Join(args, " "))
-		}
-		return stdout.Bytes(), nil
-	}
-	checkToolExists := func(ctx context.Context, name string) error {
-		if _, err := execCmd(ctx, &execReq{}, name, "--version"); err != nil {
-			return errors.Wrapf(err, "command not found: '%s'", name)
-		}
-		return nil
-	}
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "upgrade lekko to the latest version using homebrew",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(apikey) == 0 {
-				return errors.New("no api key provided")
-			}
-			ctx := cmd.Context()
-			for _, tool := range []string{"brew", "curl", "jq"} {
-				if err := checkToolExists(ctx, tool); err != nil {
-					return err
-				}
-			}
-			if _, err := execCmd(ctx, &execReq{
-				stdout:  os.Stdout,
-				stderr:  os.Stderr,
-				verbose: true,
-			}, "brew", "update"); err != nil {
-				return err
-			}
-			if _, err := execCmd(ctx, &execReq{
-				stdout:  os.Stdout,
-				stderr:  os.Stderr,
-				verbose: true,
-			}, "brew", "tap", "lekkodev/lekko"); err != nil {
-				return err
-			}
-			brewRepoOutput, err := execCmd(ctx, &execReq{}, "brew", "--repo")
-			if err != nil {
-				return err
-			}
-			brewRepo := strings.TrimSpace(string(brewRepoOutput))
-			tokenScript := fmt.Sprintf("%s/Library/Taps/lekkodev/homebrew-lekko/gen_token.sh", brewRepo)
-			tokenOutput, err := execCmd(ctx, &execReq{}, tokenScript)
-			if err != nil {
-				return err
-			}
-			token := strings.TrimSpace(string(tokenOutput))
-			if len(token) == 0 {
-				return errors.New("failed to generate token")
-			}
-			envToSet := "HOMEBREW_GITHUB_API_TOKEN"
-			_, err = execCmd(ctx, &execReq{
-				stdout:  os.Stdout,
-				stderr:  os.Stderr,
-				verbose: true,
-				env:     []string{fmt.Sprintf("%s=%s", envToSet, token)},
-			}, "brew", "upgrade", "lekko")
-			return err
+			fmt.Printf(
+				`Our CLI is currently managed by Homebrew.
+In order to upgrade, first set your API key:
+		
+	export LEKKO_API_KEY=lekko_********
+
+Next, run the following commands:
+
+	brew update
+	export HOMEBREW_GITHUB_API_TOKEN=$($(brew --repo)/Library/Taps/lekkodev/homebrew-lekko/gen_token.sh)
+	brew upgrade lekko
+
+For more information, check out our docs:
+https://app.lekko.com/docs/cli/
+`)
+			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&apikey, "apikey", "a", os.Getenv("LEKKO_APIKEY"), "apikey used to upgrade")
 	return cmd
 }


### PR DESCRIPTION
`lekko upgrade` is currently broken because `lekko` doesn't have the privilege to change the contents of the local directories managed by homebrew. 

this pr updates the command to show you what you need to run in order to perform the upgrade, and link you to docs.

```bash
$  lekkodev upgrade
Our CLI is currently managed by Homebrew.
In order to upgrade, first set your API key:

	export LEKKO_API_KEY=lekko_********

Next, run the following commands:

	brew update
	export HOMEBREW_GITHUB_API_TOKEN=$($(brew --repo)/Library/Taps/lekkodev/homebrew-lekko/gen_token.sh)
	brew upgrade lekko

For more information, check out our docs:
https://app.lekko.com/docs/cli/
```