### PR TITLE
Commit signature without github creds

### DIFF
--- a/cmd/lekko/main.go
+++ b/cmd/lekko/main.go
@@ -504,7 +504,7 @@ func commitCmd() *cobra.Command {
 			if err := r.Verify(ctx, &repo.VerifyRequest{}); err != nil {
 				return errors.Wrap(err, "verify")
 			}
-			signature, err := repo.GetCommitSignature(ctx, rs)
+			signature, err := repo.GetCommitSignature(ctx, rs, rs.GetLekkoUsername())
 			if err != nil {
 				return err
 			}

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Lekko Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type noopAuthProvider struct{}
+
+func (noopAuthProvider) GetUsername() string {
+	return ""
+}
+
+func (noopAuthProvider) GetToken() string {
+	return ""
+}
+
+func TestGetCommitSignatureNoGitHub(t *testing.T) {
+	ctx := context.Background()
+
+	lekkoUser := "test@lekko.com"
+	sign, err := GetCommitSignature(ctx, &noopAuthProvider{}, lekkoUser)
+	require.NoError(t, err)
+	assert.Equal(t, lekkoUser, sign.Email)
+	assert.Equal(t, "test", sign.Name)
+}

--- a/pkg/repo/review.go
+++ b/pkg/repo/review.go
@@ -67,7 +67,7 @@ func (r *repository) Review(ctx context.Context, title string, ghCli *gh.GithubC
 		if err := r.NewRemoteBranch(branchName); err != nil {
 			return "", errors.Wrapf(err, "new remote branch: %s", branchName)
 		}
-		signature, err := GetCommitSignature(ctx, ap)
+		signature, err := GetCommitSignature(ctx, ap, "")
 		if err != nil {
 			return "", errors.Wrap(err, "get commit signature")
 		}
@@ -76,7 +76,7 @@ func (r *repository) Review(ctx context.Context, title string, ghCli *gh.GithubC
 		}
 	} else {
 		if !clean { // commit local changes and push
-			signature, err := GetCommitSignature(ctx, ap)
+			signature, err := GetCommitSignature(ctx, ap, "")
 			if err != nil {
 				return "", errors.Wrap(err, "get commit signature")
 			}


### PR DESCRIPTION
Allow users that don't have github accounts to be coauthors of a machine commit.