### PR TITLE
Introduce type and RPC definitions for permission API methods

### DIFF
--- a/proto/lekko/bff/v1beta1/bff.proto
+++ b/proto/lekko/bff/v1beta1/bff.proto
@@ -121,7 +121,8 @@ service BFFService {
 
   rpc GetRoleUsers(GetRoleUsersRequest) returns (GetRoleUsersResponse) {}
   // Creates and deletes role assignments accordingly given a list of usernames
-  rpc UpdateRoleUsers(UpdateRoleUsersRequest) returns (UpdateRoleUsersResponse) {}
+  rpc AddUsersToRole(AddUsersToRoleRequest) returns (AddUsersToRoleResponse) {}
+  rpc RemoveUsersFromRole(RemoveUsersFromRoleRequest) returns (RemoveUsersFromRoleResponse) {}
 
   rpc GetRolePermissions(GetRolePermissionsRequest) returns (GetRolePermissionsResponse) {}
   rpc UpsertRolePermission(UpsertRolePermissionRequest) returns (UpsertRolePermissionResponse) {}
@@ -1002,7 +1003,11 @@ message GetTeamRolesResponse {
 
 message UpsertTeamRoleRequest {
   string team_name = 1;
+  // Role name to identify current role or create new role with if one does not exist.
   string role_name = 2;
+  // Can contain an updated role name.
+  // If inserting, role_name and name of updated_role should match.
+  // Team name in this object will be ignored.
   Role updated_role = 3;
 }
 
@@ -1035,13 +1040,21 @@ message GetRoleUsersResponse {
   repeated string usernames = 1;
 }
 
-message UpdateRoleUsersRequest {
+message AddUsersToRoleRequest {
   string team_name = 1;
   string role_name = 2;
   repeated string usernames = 3;
 }
 
-message UpdateRoleUsersResponse {}
+message AddUsersToRoleResponse {}
+
+message RemoveUsersFromRoleRequest {
+  string team_name = 1;
+  string role_name = 2;
+  repeated string usernames = 3;
+}
+
+message RemoveUsersFromRoleResponse {}
 
 message GetRolePermissionsRequest {
   string team_name = 1;


### PR DESCRIPTION
# Context
Task with more context on use cases for each method: [Notion](https://www.notion.so/lekko/Add-new-API-routes-related-to-permissions-bbaf8e732cff4f24950c2dbd555e77c1?pvs=4)

# Details
- Added required types and methods for Lekko permissions to BFF service definition