### PR TITLE
Use stderr for debug output for 'eval' cmd

### DIFF
--- a/cmd/lekko/feature.go
+++ b/cmd/lekko/feature.go
@@ -245,8 +245,8 @@ func featureEval() *cobra.Command {
 			if err := json.Unmarshal([]byte(jsonContext), &featureCtx); err != nil {
 				return err
 			}
-			fmt.Printf("Evaluating %s with context %s\n", logging.Bold(fmt.Sprintf("%s/%s", ns, featureName)), logging.Bold(jsonContext))
-			fmt.Printf("-------------------\n")
+			fmt.Fprintf(os.Stderr, "Evaluating %s with context %s\n", logging.Bold(fmt.Sprintf("%s/%s", ns, featureName)), logging.Bold(jsonContext))
+			fmt.Fprintf(os.Stderr, "-------------------\n")
 			anyVal, fType, path, err := r.Eval(ctx, ns, featureName, featureCtx)
 			if err != nil {
 				return err
@@ -281,9 +281,11 @@ func featureEval() *cobra.Command {
 				res = string(jsonRes)
 			}
 
-			fmt.Printf("[%s] %s\n", fType, logging.Bold(res))
+			fmt.Fprintf(os.Stderr, "[%s] ", fType)
+			fmt.Printf("%s", res)
+			fmt.Println()
 			if verbose {
-				fmt.Printf("[path] %v\n", path)
+				fmt.Fprintf(os.Stderr, "[path] %v\n", path)
 			}
 
 			return nil


### PR DESCRIPTION
Currently, debug output is being printed to stdout which makes it difficult to pipe the evaluated result to other commands. This PR updates `config eval` to print debug to stderr which enables machine usage by redirecting stderr to `/dev/null`

Before
```
> lekko config eval -n backend -c deployment-tag -t '{"environment":"production"}' 2>/dev/null
Evaluating backend/deployment-tag with context {"environment":"production"}
-------------------
[string] c84f4f2bf1a965f585f6426ddd67ec3fda61e175
```
After
```
> lekko config eval -n backend -c deployment-tag -t '{"environment":"production"}' 2>/dev/null
c84f4f2bf1a965f585f6426ddd67ec3fda61e175
```