### PR TITLE
pass commit sha of the last update

### DIFF
--- a/proto/lekko/backend/v1beta1/distribution_service.proto
+++ b/proto/lekko/backend/v1beta1/distribution_service.proto
@@ -77,6 +77,8 @@ message Feature {
   // The sha of the protobuf binary according to git.
   string sha = 2;
   lekko.feature.v1beta1.Feature feature = 3;
+  // SHA of the last commit that modified the config
+  string last_update_commit_sha = 4;
 }
 
 message ContextKey {
@@ -95,6 +97,8 @@ message FlagEvaluationEvent {
   // The node in the tree that contained the final return value of the feature.
   repeated int32 result_path = 7;
   google.protobuf.Timestamp client_event_time = 8;
+  // SHA of the last commit that modified the config
+  string last_update_commit_sha = 9;
 }
 
 message SendFlagEvaluationMetricsRequest {


### PR DESCRIPTION
# Context
For observability purposes we need to have a way to reference a specific version of the config. For example for tracking rollouts or to see what value was used during debugging.
We already have `sha` field which is git-style sha of the content, but it's hard to lookup the config content using it (unless we build some additional tooling).
We also report `commit_sha` in many places, but it's global for the repo, so it will change if there are new commits even if those commits didn't modify the specific config that we are looking at.
# Change
I propose to use sha of the last commit that modified the config as it's version. We already know it on rollout, we just need to store it and pass it around. The only issue is with local git mode as we'd need to use `git log` to get sha of the last update for every config. I think it should be fine, but worst case we can just not report it with local git setup.