### PR TITLE
Add proto definitions for API key scopes RPCs

### DIFF
--- a/proto/lekko/bff/v1beta1/bff.proto
+++ b/proto/lekko/bff/v1beta1/bff.proto
@@ -203,7 +203,7 @@ message ListAPIKeyScopesRequest {
 }
 
 message ListAPIKeyScopesResponse {
-  repeated Namespace namespaces = 1;
+  repeated Namespace enabled_namespaces = 1;
 }
 
 message UpdateAPIKeyScopesRequest {


### PR DESCRIPTION
# Context
[Task](https://www.notion.so/lekko/Namespace-scoped-API-keys-3302b92c892245e08aebe45ea1c0093f?pvs=4)

To support frontend SDK clients using API keys without potentially exposing all of their configs, we need to implement scoping API keys. We start with implementing scoping keys to namespaces.

# Details
- Added required protobuf types and RPC methods for CRUD of API key scopes