### PR TITLE
unset metadata

### DIFF
--- a/pkg/star/static/walk.go
+++ b/pkg/star/static/walk.go
@@ -528,6 +528,7 @@ func (w *walker) mutateMetadataFn(f *featurev1beta1.StaticFeature) metadataFn {
 	return func(ast *starFeatureAST) error {
 		metadataProto := f.FeatureOld.GetMetadata()
 		if metadataProto == nil {
+			ast.unset(MetadataAttrName)
 			return nil
 		}
 		metadataStarDict, err := w.genJSONStruct(metadataProto, nil)


### PR DESCRIPTION
There was an issue when `metadata` is not set in the new proto, it will leave old metadata in place, while we should remove it.
We really need some unit tests for metadata handling once we start using for non-demo things.