### PR TITLE
Remove prompt to compile when adding a config

### DIFF
--- a/cmd/lekko/feature.go
+++ b/cmd/lekko/feature.go
@@ -155,7 +155,6 @@ func featureAdd() *cobra.Command {
 				return errors.Wrap(err, "add config")
 			} else {
 				fmt.Printf("Successfully added config %s/%s at path %s\n", ns, featureName, path)
-				fmt.Printf("Make any changes you wish, and then run `lekko compile`.")
 			}
 			_, err = r.Compile(ctx, &repo.CompileRequest{})
 			return err


### PR DESCRIPTION
It's misleading because `lekko add` compiles automatically, and people need to remember to compile after making changes anyway.