### PR TITLE
Add metadata to BFF Feature proto

### DIFF
--- a/proto/lekko/bff/v1beta1/bff.proto
+++ b/proto/lekko/bff/v1beta1/bff.proto
@@ -432,10 +432,6 @@ message ContextKey {
   ContextKeyType type = 2;
 }
 
-// The configs will have metadata fields populated based on the latest rolled
-// out version of the repo.
-// If a config was newly created since, created_at will not be set.
-// If a config existed already but was updated, last_updated_at will not be set.
 message GetRepositoryContentsResponse {
   Branch branch = 1;
   NamespaceContents namespace_contents = 2;
@@ -472,6 +468,10 @@ message GetFeatureHistoryResponse {
   repeated FeatureHistoryItem history = 1;
 }
 
+// The configs will have metadata fields populated based on the latest rolled
+// out version of the repo.
+// If a config was newly created since, created_at will not be set.
+// If a config existed already but was updated, last_updated_at will not be set.
 message ConfigMetadata {
   google.protobuf.Timestamp created_at = 1;
   google.protobuf.Timestamp last_updated_at = 2;


### PR DESCRIPTION
We want to add metadata to configs returned as responses to GetRepositoryContents such as when it was created and when it was last updated. Later, we could add staleness info here as well.