### PR TITLE
Fix config eval command version support and formatting

### DIFF
--- a/cmd/lekko/feature.go
+++ b/cmd/lekko/feature.go
@@ -281,7 +281,7 @@ func featureEval() *cobra.Command {
 			}
 
 			fmt.Fprintf(os.Stderr, "[%s] ", fType)
-			fmt.Printf("%s", res)
+			fmt.Printf("%v", res)
 			fmt.Println()
 			if verbose {
 				fmt.Fprintf(os.Stderr, "[path] %v\n", path)

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -40,6 +40,8 @@ func ParseFeature(ctx context.Context, rootPath string, featureFile feature.Feat
 	case feature.NamespaceVersionV1Beta5.String():
 		fallthrough
 	case feature.NamespaceVersionV1Beta6.String():
+		fallthrough
+	case feature.NamespaceVersionV1Beta7.String():
 		var f featurev1beta1.Feature
 		contents, err := provider.GetFileContents(ctx, filepath.Join(rootPath, nsMD.Name, featureFile.CompiledProtoBinFileName))
 		if err != nil {


### PR DESCRIPTION
# Details
A couple of small changes for fixing `lekko config eval`:

1. With the introduction of namespace version v1beta7, it looks like we missed a small change that breaks eval:

    ```
    unknown version when parsing config: v1beta7
    ```

2. `lekko config eval` output formatting looked a little messed up because we were using the `%s` format arg, which is for strings.

    ```
    # old
    [bool] %!s(bool=true)
    [int] %!s(int64=3)
    # fixed
    [bool] true
    [int] 3
    ```