### PR TITLE
Add ability to pass default value to lekko config add

### DIFF
--- a/pkg/repo/feature.go
+++ b/pkg/repo/feature.go
@@ -52,7 +52,7 @@ type ConfigurationStore interface {
 	ReBuildDynamicTypeRegistry(ctx context.Context, protoDirPath string, useExternalTypes bool) (*protoregistry.Types, error)
 	GetFileDescriptorSet(ctx context.Context, protoDirPath string) (*descriptorpb.FileDescriptorSet, error)
 	Format(ctx context.Context, verbose bool) error
-	AddFeature(ctx context.Context, ns, featureName string, fType eval.ConfigType, protoMessageName string) (string, error)
+	AddFeature(ctx context.Context, ns, featureName string, fType eval.ConfigType, protoMessageName string, defaultValue interface{}) (string, error)
 	RemoveFeature(ctx context.Context, ns, featureName string) error
 	AddNamespace(ctx context.Context, name string) error
 	RemoveNamespace(ctx context.Context, ns string) error
@@ -765,7 +765,7 @@ func (r *repository) FormatFeature(ctx context.Context, ff *feature.FeatureFile,
 // the namespace doesn't exist, or
 // a feature named featureName already exists
 // Returns the path to the feature file that was written to disk.
-func (r *repository) AddFeature(ctx context.Context, ns, featureName string, fType eval.ConfigType, protoMessageName string) (string, error) {
+func (r *repository) AddFeature(ctx context.Context, ns, featureName string, fType eval.ConfigType, protoMessageName string, defaultValue interface{}) (string, error) {
 	if !isValidName(featureName) {
 		return "", errors.Wrap(ErrInvalidName, "config")
 	}
@@ -791,7 +791,7 @@ func (r *repository) AddFeature(ctx context.Context, ns, featureName string, fTy
 			return "", errors.Wrap(err, "add config from proto")
 		}
 	} else {
-		template, err = star.GetTemplate(fType, nv)
+		template, err = star.GetTemplate(fType, nv, defaultValue)
 		if err != nil {
 			return "", errors.Wrap(err, "get template")
 		}

--- a/pkg/repo/repo_integration_test.go
+++ b/pkg/repo/repo_integration_test.go
@@ -116,7 +116,7 @@ func testReview(ctx context.Context, t *testing.T, r *repository, ghCli *gh.Gith
 		if eval.ConfigType(fType) == eval.ConfigTypeProto {
 			protoMessageName = "google.protobuf.BoolValue"
 		}
-		path, err := r.AddFeature(ctx, namespace, getFeatureName(fType), eval.ConfigType(fType), protoMessageName)
+		path, err := r.AddFeature(ctx, namespace, getFeatureName(fType), eval.ConfigType(fType), protoMessageName, nil)
 		require.NoError(t, err)
 		t.Logf("wrote config to path %s\n", path)
 	}

--- a/pkg/star/templates_test.go
+++ b/pkg/star/templates_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestGetTemplate(t *testing.T) {
-	template, err := GetTemplate(eval.ConfigTypeBool, feature.NamespaceVersionV1Beta5)
+	template, err := GetTemplate(eval.ConfigTypeBool, feature.NamespaceVersionV1Beta5, nil)
 
 	require.NoError(t, err)
 	goldenFile, err := os.ReadFile("./testdata/test_get_template.star")
@@ -33,7 +33,7 @@ func TestGetTemplate(t *testing.T) {
 }
 
 func TestGetTemplateV1Beta6(t *testing.T) {
-	template, err := GetTemplate(eval.ConfigTypeBool, feature.NamespaceVersionV1Beta6)
+	template, err := GetTemplate(eval.ConfigTypeBool, feature.NamespaceVersionV1Beta6, nil)
 
 	require.NoError(t, err)
 	goldenFile, err := os.ReadFile("./testdata/test_get_template_config.star")


### PR DESCRIPTION
For general-purpose non-interactive use cases (e.g. for VS Code extension), we want to be able to pass the default value when creating configs with `lekko config add`.
This PR adds support for this for the primitive config types (bool, string, int, float)

Example:
```
lekko config add -n default -c some-config -t float -v 1.234
```