### PR TITLE
generate starlark from json

### DIFF
--- a/cmd/lekko/feature.go
+++ b/cmd/lekko/feature.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,12 +37,10 @@ import (
 	"github.com/lekkodev/cli/pkg/metadata"
 	"github.com/lekkodev/cli/pkg/repo"
 	"github.com/lekkodev/cli/pkg/secrets"
-	"github.com/lekkodev/cli/pkg/star"
 	"github.com/lekkodev/cli/pkg/star/static"
 	"github.com/lekkodev/go-sdk/pkg/eval"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -60,123 +57,7 @@ func featureCmd() *cobra.Command {
 		featureRemove(),
 		featureEval(),
 		configGroup(),
-		generateStarlarkCmd(),
 	)
-	return cmd
-}
-
-func generateStarlarkCmd() *cobra.Command {
-	var wd string
-	var ns string
-	var configName string
-	cmd := &cobra.Command{
-		Use:   "generate-starlark",
-		Short: "generate starlark from the json representation and compile it",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			r, err := repo.NewLocal(wd, secrets.NewSecretsOrFail())
-			if err != nil {
-				return errors.Wrap(err, "failed to open config repo")
-			}
-			rootMD, _, err := r.ParseMetadata(ctx)
-			if err != nil {
-				return errors.Wrap(err, "failed to parse config repo metadata")
-			}
-			// re-build proto
-			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory, rootMD.UseExternalTypes)
-			if err != nil {
-				return errors.Wrap(err, "rebuild type registry")
-			}
-
-			// read compiled proto from json
-			configFile := feature.NewFeatureFile(ns, configName)
-			contents, err := r.GetFileContents(ctx, filepath.Join(ns, configFile.CompiledJSONFileName))
-			if err != nil {
-				return err
-			}
-			var configProto featurev1beta1.Feature
-			err = protojson.UnmarshalOptions{Resolver: registry}.Unmarshal(contents, &configProto)
-			if err != nil {
-				return err
-			}
-
-			// create a new starlark file from a template (based on the config type)
-			var starBytes []byte
-			starImports := make([]*featurev1beta1.ImportStatement, 0)
-
-			if configProto.Type == featurev1beta1.FeatureType_FEATURE_TYPE_PROTO {
-				typeURL := configProto.GetTree().GetDefault().GetTypeUrl()
-				messageType, found := strings.CutPrefix(typeURL, "type.googleapis.com/")
-				if !found {
-					return fmt.Errorf("can't parse type url: %s", typeURL)
-				}
-				starInputs, err := r.BuildProtoStarInputs(ctx, messageType, feature.LatestNamespaceVersion())
-				if err != nil {
-					return err
-				}
-				starBytes, err = star.RenderExistingProtoTemplate(*starInputs, feature.LatestNamespaceVersion())
-				if err != nil {
-					return err
-				}
-				for importPackage, importAlias := range starInputs.Packages {
-					starImports = append(starImports, &featurev1beta1.ImportStatement{
-						Lhs: &featurev1beta1.IdentExpr{
-							Token: importAlias,
-						},
-						Operator: "=",
-						Rhs: &featurev1beta1.ImportExpr{
-							Dot: &featurev1beta1.DotExpr{
-								X:    "proto",
-								Name: "package",
-							},
-							Args: []string{importPackage},
-						},
-					})
-				}
-			} else {
-				starBytes, err = star.GetTemplate(eval.ConfigTypeFromProto(configProto.Type), feature.LatestNamespaceVersion(), nil)
-				if err != nil {
-					return err
-				}
-			}
-
-			// mutate starlark with the actual config
-			walker := static.NewWalker("", starBytes, registry, feature.NamespaceVersionV1Beta7)
-			newBytes, err := walker.Mutate(&featurev1beta1.StaticFeature{
-				Key:  configProto.Key,
-				Type: configProto.GetType(),
-				Feature: &featurev1beta1.FeatureStruct{
-					Description: configProto.GetDescription(),
-				},
-				FeatureOld: &configProto,
-				Imports:    starImports,
-			})
-			if err != nil {
-				return errors.Wrap(err, "walker mutate")
-			}
-			// write starlark to disk
-			if err := r.WriteFile(path.Join(ns, configFile.StarlarkFileName), newBytes, 0600); err != nil {
-				return errors.Wrap(err, "write after mutation")
-			}
-
-			// compile newly generated starlark file
-			_, err = r.Compile(ctx, &repo.CompileRequest{
-				Registry:        registry,
-				NamespaceFilter: ns,
-				FeatureFilter:   configName,
-			})
-			if err != nil {
-				return errors.Wrap(err, "compile after mutation")
-			}
-
-			return nil
-		},
-	}
-	cmd.Flags().StringVarP(&ns, "namespace", "n", "", "namespace to add config in")
-	cmd.Flags().StringVarP(&configName, "config", "c", "", "name of config to add")
-	// TODO: this doesn't fully work, as it's not propagated everywhere
-	// for example `buf lint` when openning the repo
-	cmd.Flags().StringVarP(&wd, "repo-path", "r", ".", "path to configuration repository")
 	return cmd
 }
 

--- a/cmd/lekko/gen.go
+++ b/cmd/lekko/gen.go
@@ -21,6 +21,8 @@ import (
 	"go/format"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -31,8 +33,12 @@ import (
 	rulesv1beta3 "buf.build/gen/go/lekkodev/cli/protocolbuffers/go/lekko/rules/v1beta3"
 	"github.com/iancoleman/strcase"
 	"github.com/lainio/err2/try"
+	"github.com/lekkodev/cli/pkg/feature"
 	"github.com/lekkodev/cli/pkg/repo"
 	"github.com/lekkodev/cli/pkg/secrets"
+	"github.com/lekkodev/cli/pkg/star"
+	"github.com/lekkodev/cli/pkg/star/static"
+	"github.com/lekkodev/go-sdk/pkg/eval"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/modfile"
@@ -44,6 +50,131 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
+
+func genCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gen",
+		Short: "generate library code from configs",
+	}
+	cmd.AddCommand(genGoCmd())
+	cmd.AddCommand(geneStarlarkCmd())
+	return cmd
+}
+
+func geneStarlarkCmd() *cobra.Command {
+	var wd string
+	var ns string
+	var configName string
+	cmd := &cobra.Command{
+		Use:   "starlark",
+		Short: "generate Starlark from the json representation and compile it",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			r, err := repo.NewLocal(wd, secrets.NewSecretsOrFail())
+			if err != nil {
+				return errors.Wrap(err, "failed to open config repo")
+			}
+			rootMD, _, err := r.ParseMetadata(ctx)
+			if err != nil {
+				return errors.Wrap(err, "failed to parse config repo metadata")
+			}
+			// re-build proto
+			registry, err := r.ReBuildDynamicTypeRegistry(ctx, rootMD.ProtoDirectory, rootMD.UseExternalTypes)
+			if err != nil {
+				return errors.Wrap(err, "rebuild type registry")
+			}
+
+			// read compiled proto from json
+			configFile := feature.NewFeatureFile(ns, configName)
+			contents, err := r.GetFileContents(ctx, filepath.Join(ns, configFile.CompiledJSONFileName))
+			if err != nil {
+				return err
+			}
+			var configProto featurev1beta1.Feature
+			err = protojson.UnmarshalOptions{Resolver: registry}.Unmarshal(contents, &configProto)
+			if err != nil {
+				return err
+			}
+
+			// create a new starlark file from a template (based on the config type)
+			var starBytes []byte
+			starImports := make([]*featurev1beta1.ImportStatement, 0)
+
+			if configProto.Type == featurev1beta1.FeatureType_FEATURE_TYPE_PROTO {
+				typeURL := configProto.GetTree().GetDefault().GetTypeUrl()
+				messageType, found := strings.CutPrefix(typeURL, "type.googleapis.com/")
+				if !found {
+					return fmt.Errorf("can't parse type url: %s", typeURL)
+				}
+				starInputs, err := r.BuildProtoStarInputs(ctx, messageType, feature.LatestNamespaceVersion())
+				if err != nil {
+					return err
+				}
+				starBytes, err = star.RenderExistingProtoTemplate(*starInputs, feature.LatestNamespaceVersion())
+				if err != nil {
+					return err
+				}
+				for importPackage, importAlias := range starInputs.Packages {
+					starImports = append(starImports, &featurev1beta1.ImportStatement{
+						Lhs: &featurev1beta1.IdentExpr{
+							Token: importAlias,
+						},
+						Operator: "=",
+						Rhs: &featurev1beta1.ImportExpr{
+							Dot: &featurev1beta1.DotExpr{
+								X:    "proto",
+								Name: "package",
+							},
+							Args: []string{importPackage},
+						},
+					})
+				}
+			} else {
+				starBytes, err = star.GetTemplate(eval.ConfigTypeFromProto(configProto.Type), feature.LatestNamespaceVersion(), nil)
+				if err != nil {
+					return err
+				}
+			}
+
+			// mutate starlark with the actual config
+			walker := static.NewWalker("", starBytes, registry, feature.NamespaceVersionV1Beta7)
+			newBytes, err := walker.Mutate(&featurev1beta1.StaticFeature{
+				Key:  configProto.Key,
+				Type: configProto.GetType(),
+				Feature: &featurev1beta1.FeatureStruct{
+					Description: configProto.GetDescription(),
+				},
+				FeatureOld: &configProto,
+				Imports:    starImports,
+			})
+			if err != nil {
+				return errors.Wrap(err, "walker mutate")
+			}
+			// write starlark to disk
+			if err := r.WriteFile(path.Join(ns, configFile.StarlarkFileName), newBytes, 0600); err != nil {
+				return errors.Wrap(err, "write after mutation")
+			}
+
+			// compile newly generated starlark file
+			_, err = r.Compile(ctx, &repo.CompileRequest{
+				Registry:        registry,
+				NamespaceFilter: ns,
+				FeatureFilter:   configName,
+			})
+			if err != nil {
+				return errors.Wrap(err, "compile after mutation")
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&ns, "namespace", "n", "", "namespace to add config in")
+	cmd.Flags().StringVarP(&configName, "config", "c", "", "name of config to add")
+	// TODO: this doesn't fully work, as it's not propagated everywhere
+	// for example `buf lint` when openning the repo
+	cmd.Flags().StringVarP(&wd, "repo-path", "r", ".", "path to configuration repository")
+	return cmd
+}
 
 var typeRegistry *protoregistry.Types
 
@@ -235,11 +366,6 @@ var StaticConfig = map[string]map[string][]byte{
 	cmd.Flags().StringVarP(&wd, "config-path", "c", ".", "path to configuration repository")
 	cmd.Flags().StringVarP(&of, "output", "o", "lekko.go", "output file")
 	return cmd
-}
-
-var genCmd = &cobra.Command{
-	Use:   "gen",
-	Short: "generate library code from configs",
 }
 
 func genGoForFeature(ctx context.Context, r repo.ConfigurationRepository, f *featurev1beta1.Feature, ns string, staticCtxType *protoImport) (string, error) {

--- a/cmd/lekko/main.go
+++ b/cmd/lekko/main.go
@@ -66,8 +66,7 @@ func main() {
 	experimentalCmd.AddCommand(cleanupCmd)
 	experimentalCmd.AddCommand(formatCmd())
 	// code generation
-	genCmd.AddCommand(genGoCmd())
-	experimentalCmd.AddCommand(genCmd)
+	experimentalCmd.AddCommand(genCmd())
 	rootCmd.AddCommand(experimentalCmd)
 
 	logging.InitColors()


### PR DESCRIPTION
# Change
Added `config generate-starlark` command to generate .star file from json representation of a config. It's easy to make it work with `.proto.bin`, but I went with json as it's easier to generate.
This is mostly just plumbing existing code together.

# Test plan
- modify a json and run `lekko config generate-starlark -n default -c puppy_number`, then see that the change was reflected
- also test in https://github.com/lekkodev/node-server-sdk/pull/29