### PR TITLE
Emit native ts

### DIFF
--- a/cmd/lekko/gen.go
+++ b/cmd/lekko/gen.go
@@ -753,12 +753,12 @@ func getTSInterface(d protoreflect.MessageDescriptor) (string, error) {
 		case protoreflect.MessageKind:
 			t = string(f.Message().Name())
 			// TODO add more
-    default:
-      t = f.Kind().String()
+		default:
+			t = f.Kind().String()
 		}
-    if f.Cardinality() == protoreflect.Repeated {
-      t = "[]" + t
-    }
+		if f.Cardinality() == protoreflect.Repeated {
+			t = "[]" + t
+		}
 		fields = append(fields, fmt.Sprintf("%s: %s;", f.TextName(), t))
 	}
 


### PR DESCRIPTION
This is about as janky as our go-lang native language integration.  It's based on the core idea that we can (eventually..) make everything we care about part of the proto definition of a config.  We currently don't let there be things like comments per rule, or anything like that, so it's destructive.  It also doesn't handle things like optional in ts interfaces, since we don't support that as an annotation in proto yet.

But.. It let's me generate the file to start with, and I really don't want to do that manually, and I really don't want to not use native lang