### PR TITLE
Log out of both providers by default

### DIFF
--- a/cmd/lekko/auth.go
+++ b/cmd/lekko/auth.go
@@ -76,13 +76,11 @@ func logoutCmd() *cobra.Command {
 			return secrets.WithWriteSecrets(func(ws secrets.WriteSecrets) error {
 				auth := oauth.NewOAuth(lekko.NewBFFClient(ws))
 				for _, provider := range providers {
-					if err := auth.Logout(cmd.Context(), provider, ws, !pIsSet); err != nil {
+					if err := auth.Logout(cmd.Context(), provider, ws); err != nil {
 						return err
 					}
 				}
-				if !pIsSet {
-					auth.Status(cmd.Context(), true, ws)
-				}
+				auth.Status(cmd.Context(), true, ws)
 				return nil
 			})
 		},

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -85,7 +85,7 @@ func maskToken(token, prefix string) string {
 // Logout implicitly expires the relevant credentials by
 // deleting them. TODO: explore explicitly expiring these
 // credentials with each provider.
-func (a *OAuth) Logout(ctx context.Context, provider string, ws secrets.WriteSecrets, noStatus bool) error {
+func (a *OAuth) Logout(ctx context.Context, provider string, ws secrets.WriteSecrets) error {
 	if !(provider == "lekko" || provider == "github") {
 		return fmt.Errorf("provider must be one of 'lekko' or 'github'")
 	}
@@ -99,9 +99,6 @@ func (a *OAuth) Logout(ctx context.Context, provider string, ws secrets.WriteSec
 	if provider == "github" {
 		ws.SetGithubToken("")
 		ws.SetGithubUser("")
-	}
-	if !noStatus {
-		a.Status(ctx, true, ws)
 	}
 	return nil
 }


### PR DESCRIPTION
We want `lekko auth logout` to log out of both providers, previously we required `-p` and couldn't log out of both at the same time.