### PR TITLE
Add optional params when there is a presence check

### DIFF
--- a/cmd/lekko/gen/ts.go
+++ b/cmd/lekko/gen/ts.go
@@ -414,21 +414,21 @@ func getOptionalVariables(rule *rulesv1beta3.Rule, optionalVariables map[string]
 }
 
 func createUndefinedSafeJSExpression(contextKey string, comparisonValue *structpb.Value, operator string, optionalVariables map[string]string, marshalOptions protojson.MarshalOptions, usedVariables map[string]string) string {
-    usedVariables[contextKey] = structpbValueToKindString(comparisonValue)
+	usedVariables[contextKey] = structpbValueToKindString(comparisonValue)
 
-    marshaledValue, err := marshalOptions.Marshal(comparisonValue)
+	marshaledValue, err := marshalOptions.Marshal(comparisonValue)
 	if err != nil {
-        return fmt.Sprintf("Error marshaling comparison value: %v", err)
-    }
-	
+		return fmt.Sprintf("Error marshaling comparison value: %v", err)
+	}
+
 	marshaledValueStr := string(marshaledValue)
 
-    methodCall := fmt.Sprintf("%s.%s(%s)", contextKey, operator, marshaledValueStr)
-    if _, ok := optionalVariables[contextKey]; ok {
-        methodCall = fmt.Sprintf("%s?.%s(%s)", contextKey, operator, marshaledValueStr)
-    }
+	methodCall := fmt.Sprintf("%s.%s(%s)", contextKey, operator, marshaledValueStr)
+	if _, ok := optionalVariables[contextKey]; ok {
+		methodCall = fmt.Sprintf("%s?.%s(%s)", contextKey, operator, marshaledValueStr)
+	}
 
-    return fmt.Sprintf("(%s)", methodCall)
+	return fmt.Sprintf("(%s)", methodCall)
 }
 
 func translateRuleTS(rule *rulesv1beta3.Rule, usedVariables map[string]string, optionalVariables map[string]string) string {


### PR DESCRIPTION
Adds presence ts code gen

Makes params optional if there is a check for presence.  Will use "string | boolean | number" type if there are no comparison values or grab the type from the usedVariables if it ever was compared to a value.

If there are any presence checks, we'll use optional value safe methods on strings 

<img width="772" alt="Screenshot 2024-04-15 at 4 01 08 PM" src="https://github.com/lekkodev/cli/assets/116435/758c843e-9522-4db7-b35b-9482650ce17c">
